### PR TITLE
dot child matcher

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1107,7 +1107,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Normington</td>
-<td class="center">Expires 10 January 2021</td>
+<td class="center">Expires 15 January 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1120,12 +1120,12 @@ dd.break {
 <dd class="internet-draft">draft-normington-jsonpath-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-09" class="published">9 July 2020</time>
+<time datetime="2020-07-14" class="published">14 July 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-01-10">10 January 2021</time></dd>
+<dd class="expires"><time datetime="2021-01-15">15 January 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -1164,7 +1164,7 @@ dd.break {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 10 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 15 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1217,10 +1217,18 @@ dd.break {
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-implementation-2" class="xref">Implementation</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
-                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-2" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-3" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.5">
-                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-2" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-3" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6">
+                <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="xref">2.6</a>.  <a href="#name-matchers-2" class="xref">Matchers</a><a href="#section-toc.1-1.2.2.6.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.1">
+                    <p id="section-toc.1-1.2.2.6.2.1.1"><a href="#section-2.6.1" class="xref">2.6.1</a>.  <a href="#name-dot-child-matcher-2" class="xref">Dot Child Matcher</a><a href="#section-toc.1-1.2.2.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 </ul>
 </li>
@@ -1307,8 +1315,8 @@ dd.break {
 <p id="section-2.3-6">If a syntactially invalid JSON document is provided, any implementation SHOULD return an error.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.4">
-        <h3 id="name-syntax-2">
-<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-2" class="section-name selfRef">Syntax</a>
+        <h3 id="name-syntax-3">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-3" class="section-name selfRef">Syntax</a>
         </h3>
 <p id="section-2.4-1">Syntactically, a JSONPath consists of a root selector (<code>$</code>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
 <div id="section-2.4-2">
@@ -1320,26 +1328,65 @@ root-selector = %x24               ; $ selects document root node
 <p id="section-2.4-3">The syntax and semantics of each matcher is defined below.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.5">
-        <h3 id="name-semantics-2">
-<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-2" class="section-name selfRef">Semantics</a>
+        <h3 id="name-semantics-3">
+<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-3" class="section-name selfRef">Semantics</a>
         </h3>
-<p id="section-2.5-1">The root selector <code>$</code> not only selects the root node of the input document, but it produces as output a list consisting of one node: the input document.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
-<p id="section-2.5-2">After the root selector, the remainder of the JSONPath passes lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
-               matching the JSONPath to the input JSON document.<a href="#section-2.5-2" class="pilcrow">¶</a></p>
-<p id="section-2.5-3">Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher matches zero or more descendants of the node.
-               The output list of nodes of a matcher is the concatenation of the lists of matching descendents for each input node.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
-<p id="section-2.5-4">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSONPath
-               <code>$.a[*].b</code> produces the following list of matching nodes: <code>0</code>, <code>1</code>, <code>2</code>. Let's walk through this in detail.<a href="#section-2.5-4" class="pilcrow">¶</a></p>
-<p id="section-2.5-5">The JSONPath consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-5" class="pilcrow">¶</a></p>
-<p id="section-2.5-6">Firstly, <code>$</code> matches the input document and produces a list of one node: the input document.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
-<p id="section-2.5-7">Next, <code>.a</code> matches any values of input nodes (which are objects) corresponding to the key <code>"a"</code>.
-               The result is again a list of one node: <code>[{"b":0},{"b":1},{"b":2}]</code>.<a href="#section-2.5-7" class="pilcrow">¶</a></p>
-<p id="section-2.5-8">Next, <code>[*]</code> matches all the elements of input nodes which are arrays.
-               The result is a list of three nodes: <code>{"b":0}</code>, <code>{"b":1}</code>, and <code>{"b":2}</code>.<a href="#section-2.5-8" class="pilcrow">¶</a></p>
-<p id="section-2.5-9">Finally, <code>.b</code> matches any values of input nodes (which are objects) corresponding to the key <code>"b"</code>.
-               The result is the concatenation of three lists each of length one containing <code>0</code>, <code>1</code>, <code>2</code>, respectively.<a href="#section-2.5-9" class="pilcrow">¶</a></p>
-<p id="section-2.5-10">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.<a href="#section-2.5-10" class="pilcrow">¶</a></p>
-<p id="section-2.5-11">In what follows, the semantics of each matcher are defined for each type of node.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
+<p id="section-2.5-1">The root selector <code>$</code> not only selects the root node of the input document, but it also produces as output a list consisting of one node: the input document.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
+<p id="section-2.5-2">A matcher may match a node and, if it matches, may then select zero or more descendants of the node for further processing.
+               But there's more to it than this: each matcher acts on a list of nodes and produces a list of nodes, as follows.<a href="#section-2.5-2" class="pilcrow">¶</a></p>
+<p id="section-2.5-3">After the root selector, the remainder of the JSONPath is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
+               matching the JSONPath to the input JSON document.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
+<p id="section-2.5-4">Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher may or may not match the node. If the matcher
+               matches the node, it selects zero or more descendants of the node.
+               The output list of nodes of a matcher is the concatenation of the lists of selected descendents for each input node.<a href="#section-2.5-4" class="pilcrow">¶</a></p>
+<p id="section-2.5-5">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSONPath
+               <code>$.a[*].b</code> selects the following list of nodes: <code>0</code>, <code>1</code>, <code>2</code>. Let's walk through this in detail.<a href="#section-2.5-5" class="pilcrow">¶</a></p>
+<p id="section-2.5-6">The JSONPath consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
+<p id="section-2.5-7">Firstly, <code>$</code> matches the input document and selects the root node which is the input document. So the result is a list consisting of just the root node.<a href="#section-2.5-7" class="pilcrow">¶</a></p>
+<p id="section-2.5-8">Next, <code>.a</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"a"</code>.
+               The result is again a list of one node: <code>[{"b":0},{"b":1},{"b":2}]</code>.<a href="#section-2.5-8" class="pilcrow">¶</a></p>
+<p id="section-2.5-9">Next, <code>[*]</code> matches any input node which is an array and selects all the elements of the input node.
+               The result is a list of three nodes: <code>{"b":0}</code>, <code>{"b":1}</code>, and <code>{"b":2}</code>.<a href="#section-2.5-9" class="pilcrow">¶</a></p>
+<p id="section-2.5-10">Finally, <code>.b</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"b"</code>.
+               The result is the concatenation of three lists each of length one containing <code>0</code>, <code>1</code>, <code>2</code>, respectively.<a href="#section-2.5-10" class="pilcrow">¶</a></p>
+<p id="section-2.5-11">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
+<p id="section-2.5-12">In what follows, the semantics of each matcher are defined for each type of node.<a href="#section-2.5-12" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6">
+        <h3 id="name-matchers-2">
+<a href="#section-2.6" class="section-number selfRef">2.6. </a><a href="#name-matchers-2" class="section-name selfRef">Matchers</a>
+        </h3>
+<section id="section-2.6.1">
+          <h4 id="name-dot-child-matcher-2">
+<a href="#section-2.6.1" class="section-number selfRef">2.6.1. </a><a href="#name-dot-child-matcher-2" class="section-name selfRef">Dot Child Matcher</a>
+          </h4>
+<section id="section-2.6.1.1">
+            <h5 id="name-syntax-4">
+<a href="#name-syntax-4" class="section-name selfRef">Syntax</a>
+            </h5>
+<p id="section-2.6.1.1-1">A dot child matcher has a key known as a dot child name or a single asterisk (<code>*</code>).<a href="#section-2.6.1.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.1-2">A dot child name corresponds to a key in a JSON object, without the surrounding double quotes (<code>"</code>).<a href="#section-2.6.1.1-2" class="pilcrow">¶</a></p>
+<div id="section-2.6.1.1-3">
+<pre class="sourcecode lang-abnf">
+matcher = dot-child             ; see below for alternatives
+dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
+            %x2E %x2A             ; .*
+dot-child-name = TBD
+</pre><a href="#section-2.6.1.1-3" class="pilcrow">¶</a>
+</div>
+<p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Bracket Child Name" in (reference TBD).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6.1.2">
+            <h5 id="name-semantics-4">
+<a href="#name-semantics-4" class="section-name selfRef">Semantics</a>
+            </h5>
+<p id="section-2.6.1.2-1">A dot child name which is not a single asterisk (<code>*</code>) matches any node which is an object having a key equal to the dot child name
+                  and selects the value corresponding to that key.
+                  It does not match a node which is not an object.<a href="#section-2.6.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.2-2">A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
+                     It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
+</section>
+</section>
 </section>
 </section>
 <div id="IANA">

--- a/draft-normington-jsonpath-latest.html
+++ b/draft-normington-jsonpath-latest.html
@@ -1107,7 +1107,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Normington</td>
-<td class="center">Expires 10 January 2021</td>
+<td class="center">Expires 15 January 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1120,12 +1120,12 @@ dd.break {
 <dd class="internet-draft">draft-normington-jsonpath-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-09" class="published">9 July 2020</time>
+<time datetime="2020-07-14" class="published">14 July 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-01-10">10 January 2021</time></dd>
+<dd class="expires"><time datetime="2021-01-15">15 January 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -1164,7 +1164,7 @@ dd.break {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 10 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 15 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1217,10 +1217,18 @@ dd.break {
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-implementation-2" class="xref">Implementation</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
-                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-2" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-3" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.5">
-                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-2" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-3" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6">
+                <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="xref">2.6</a>.  <a href="#name-matchers-2" class="xref">Matchers</a><a href="#section-toc.1-1.2.2.6.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.1">
+                    <p id="section-toc.1-1.2.2.6.2.1.1"><a href="#section-2.6.1" class="xref">2.6.1</a>.  <a href="#name-dot-child-matcher-2" class="xref">Dot Child Matcher</a><a href="#section-toc.1-1.2.2.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 </ul>
 </li>
@@ -1307,8 +1315,8 @@ dd.break {
 <p id="section-2.3-6">If a syntactially invalid JSON document is provided, any implementation SHOULD return an error.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.4">
-        <h3 id="name-syntax-2">
-<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-2" class="section-name selfRef">Syntax</a>
+        <h3 id="name-syntax-3">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-3" class="section-name selfRef">Syntax</a>
         </h3>
 <p id="section-2.4-1">Syntactically, a JSONPath consists of a root selector (<code>$</code>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
 <div id="section-2.4-2">
@@ -1320,26 +1328,65 @@ root-selector = %x24               ; $ selects document root node
 <p id="section-2.4-3">The syntax and semantics of each matcher is defined below.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.5">
-        <h3 id="name-semantics-2">
-<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-2" class="section-name selfRef">Semantics</a>
+        <h3 id="name-semantics-3">
+<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-3" class="section-name selfRef">Semantics</a>
         </h3>
-<p id="section-2.5-1">The root selector <code>$</code> not only selects the root node of the input document, but it produces as output a list consisting of one node: the input document.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
-<p id="section-2.5-2">After the root selector, the remainder of the JSONPath passes lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
-               matching the JSONPath to the input JSON document.<a href="#section-2.5-2" class="pilcrow">¶</a></p>
-<p id="section-2.5-3">Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher matches zero or more descendants of the node.
-               The output list of nodes of a matcher is the concatenation of the lists of matching descendents for each input node.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
-<p id="section-2.5-4">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSONPath
-               <code>$.a[*].b</code> produces the following list of matching nodes: <code>0</code>, <code>1</code>, <code>2</code>. Let's walk through this in detail.<a href="#section-2.5-4" class="pilcrow">¶</a></p>
-<p id="section-2.5-5">The JSONPath consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-5" class="pilcrow">¶</a></p>
-<p id="section-2.5-6">Firstly, <code>$</code> matches the input document and produces a list of one node: the input document.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
-<p id="section-2.5-7">Next, <code>.a</code> matches any values of input nodes (which are objects) corresponding to the key <code>"a"</code>.
-               The result is again a list of one node: <code>[{"b":0},{"b":1},{"b":2}]</code>.<a href="#section-2.5-7" class="pilcrow">¶</a></p>
-<p id="section-2.5-8">Next, <code>[*]</code> matches all the elements of input nodes which are arrays.
-               The result is a list of three nodes: <code>{"b":0}</code>, <code>{"b":1}</code>, and <code>{"b":2}</code>.<a href="#section-2.5-8" class="pilcrow">¶</a></p>
-<p id="section-2.5-9">Finally, <code>.b</code> matches any values of input nodes (which are objects) corresponding to the key <code>"b"</code>.
-               The result is the concatenation of three lists each of length one containing <code>0</code>, <code>1</code>, <code>2</code>, respectively.<a href="#section-2.5-9" class="pilcrow">¶</a></p>
-<p id="section-2.5-10">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.<a href="#section-2.5-10" class="pilcrow">¶</a></p>
-<p id="section-2.5-11">In what follows, the semantics of each matcher are defined for each type of node.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
+<p id="section-2.5-1">The root selector <code>$</code> not only selects the root node of the input document, but it also produces as output a list consisting of one node: the input document.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
+<p id="section-2.5-2">A matcher may match a node and, if it matches, may then select zero or more descendants of the node for further processing.
+               But there's more to it than this: each matcher acts on a list of nodes and produces a list of nodes, as follows.<a href="#section-2.5-2" class="pilcrow">¶</a></p>
+<p id="section-2.5-3">After the root selector, the remainder of the JSONPath is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
+               matching the JSONPath to the input JSON document.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
+<p id="section-2.5-4">Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher may or may not match the node. If the matcher
+               matches the node, it selects zero or more descendants of the node.
+               The output list of nodes of a matcher is the concatenation of the lists of selected descendents for each input node.<a href="#section-2.5-4" class="pilcrow">¶</a></p>
+<p id="section-2.5-5">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSONPath
+               <code>$.a[*].b</code> selects the following list of nodes: <code>0</code>, <code>1</code>, <code>2</code>. Let's walk through this in detail.<a href="#section-2.5-5" class="pilcrow">¶</a></p>
+<p id="section-2.5-6">The JSONPath consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
+<p id="section-2.5-7">Firstly, <code>$</code> matches the input document and selects the root node which is the input document. So the result is a list consisting of just the root node.<a href="#section-2.5-7" class="pilcrow">¶</a></p>
+<p id="section-2.5-8">Next, <code>.a</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"a"</code>.
+               The result is again a list of one node: <code>[{"b":0},{"b":1},{"b":2}]</code>.<a href="#section-2.5-8" class="pilcrow">¶</a></p>
+<p id="section-2.5-9">Next, <code>[*]</code> matches any input node which is an array and selects all the elements of the input node.
+               The result is a list of three nodes: <code>{"b":0}</code>, <code>{"b":1}</code>, and <code>{"b":2}</code>.<a href="#section-2.5-9" class="pilcrow">¶</a></p>
+<p id="section-2.5-10">Finally, <code>.b</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"b"</code>.
+               The result is the concatenation of three lists each of length one containing <code>0</code>, <code>1</code>, <code>2</code>, respectively.<a href="#section-2.5-10" class="pilcrow">¶</a></p>
+<p id="section-2.5-11">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
+<p id="section-2.5-12">In what follows, the semantics of each matcher are defined for each type of node.<a href="#section-2.5-12" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6">
+        <h3 id="name-matchers-2">
+<a href="#section-2.6" class="section-number selfRef">2.6. </a><a href="#name-matchers-2" class="section-name selfRef">Matchers</a>
+        </h3>
+<section id="section-2.6.1">
+          <h4 id="name-dot-child-matcher-2">
+<a href="#section-2.6.1" class="section-number selfRef">2.6.1. </a><a href="#name-dot-child-matcher-2" class="section-name selfRef">Dot Child Matcher</a>
+          </h4>
+<section id="section-2.6.1.1">
+            <h5 id="name-syntax-4">
+<a href="#name-syntax-4" class="section-name selfRef">Syntax</a>
+            </h5>
+<p id="section-2.6.1.1-1">A dot child matcher has a key known as a dot child name or a single asterisk (<code>*</code>).<a href="#section-2.6.1.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.1-2">A dot child name corresponds to a key in a JSON object, without the surrounding double quotes (<code>"</code>).<a href="#section-2.6.1.1-2" class="pilcrow">¶</a></p>
+<div id="section-2.6.1.1-3">
+<pre class="sourcecode lang-abnf">
+matcher = dot-child             ; see below for alternatives
+dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
+            %x2E %x2A             ; .*
+dot-child-name = TBD
+</pre><a href="#section-2.6.1.1-3" class="pilcrow">¶</a>
+</div>
+<p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Bracket Child Name" in (reference TBD).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6.1.2">
+            <h5 id="name-semantics-4">
+<a href="#name-semantics-4" class="section-name selfRef">Semantics</a>
+            </h5>
+<p id="section-2.6.1.2-1">A dot child name which is not a single asterisk (<code>*</code>) matches any node which is an object having a key equal to the dot child name
+                  and selects the value corresponding to that key.
+                  It does not match a node which is not an object.<a href="#section-2.6.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.2-2">A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
+                     It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
+</section>
+</section>
 </section>
 </section>
 <div id="IANA">

--- a/draft-normington-jsonpath-latest.txt
+++ b/draft-normington-jsonpath-latest.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                       G. Normington, Ed.
 Internet-Draft                                              VMware, Inc.
-Intended status: Standards Track                             9 July 2020
-Expires: 10 January 2021
+Intended status: Standards Track                            14 July 2020
+Expires: 15 January 2021
 
 
                  JavaScript Object Notation (JSON) Path
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 10 January 2021.
+   This Internet-Draft will expire on 15 January 2021.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Normington               Expires 10 January 2021                [Page 1]
+Normington               Expires 15 January 2021                [Page 1]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -72,19 +72,21 @@ Table of Contents
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   2
      1.2.  ABNF Syntax . . . . . . . . . . . . . . . . . . . . . . .   2
-   2.  JSONPath Syntax and Semantics . . . . . . . . . . . . . . . .   2
+   2.  JSONPath Syntax and Semantics . . . . . . . . . . . . . . . .   3
      2.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   3
      2.3.  Implementation  . . . . . . . . . . . . . . . . . . . . .   3
      2.4.  Syntax  . . . . . . . . . . . . . . . . . . . . . . . . .   4
      2.5.  Semantics . . . . . . . . . . . . . . . . . . . . . . . .   4
-   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   5
-   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
-   5.  Alternatives  . . . . . . . . . . . . . . . . . . . . . . . .   5
-   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   5
-     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   5
-     6.2.  Informative References  . . . . . . . . . . . . . . . . .   5
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   6
+     2.6.  Matchers  . . . . . . . . . . . . . . . . . . . . . . . .   5
+       2.6.1.  Dot Child Matcher . . . . . . . . . . . . . . . . . .   5
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   5.  Alternatives  . . . . . . . . . . . . . . . . . . . . . . . .   6
+   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
+     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   6
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .   6
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   7
 
 1.  Introduction
 
@@ -104,15 +106,15 @@ Table of Contents
    The syntax in this document conforms to ABNF as defined by RFC 5234
    [RFC5234].
 
-2.  JSONPath Syntax and Semantics
 
 
 
-
-Normington               Expires 10 January 2021                [Page 2]
+Normington               Expires 15 January 2021                [Page 2]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
+
+2.  JSONPath Syntax and Semantics
 
 2.1.  Overview
 
@@ -163,9 +165,7 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
 
 
-
-
-Normington               Expires 10 January 2021                [Page 3]
+Normington               Expires 15 January 2021                [Page 3]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -184,58 +184,103 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 2.5.  Semantics
 
    The root selector "$" not only selects the root node of the input
-   document, but it produces as output a list consisting of one node:
-   the input document.
+   document, but it also produces as output a list consisting of one
+   node: the input document.
 
-   After the root selector, the remainder of the JSONPath passes lists
-   of nodes from one matcher to the next ending up with a list of nodes
-   which is the result of matching the JSONPath to the input JSON
-   document.
+   A matcher may match a node and, if it matches, may then select zero
+   or more descendants of the node for further processing.  But there's
+   more to it than this: each matcher acts on a list of nodes and
+   produces a list of nodes, as follows.
+
+   After the root selector, the remainder of the JSONPath is processed
+   by passing lists of nodes from one matcher to the next ending up with
+   a list of nodes which is the result of matching the JSONPath to the
+   input JSON document.
 
    Each matcher acts on its input list of nodes as follows.  For each
-   node in the list, the matcher matches zero or more descendants of the
+   node in the list, the matcher may or may not match the node.  If the
+   matcher matches the node, it selects zero or more descendants of the
    node.  The output list of nodes of a matcher is the concatenation of
-   the lists of matching descendents for each input node.
+   the lists of selected descendents for each input node.
 
    A specific, non-normative example will make this clearer.  Suppose
    the input document is: "{"a":[{"b":0},{"b":1},{"b":2}]}".  As we will
-   see later, the JSONPath "$.a[*].b" produces the following list of
-   matching nodes: "0", "1", "2".  Let's walk through this in detail.
+   see later, the JSONPath "$.a[*].b" selects the following list of
+   nodes: "0", "1", "2".  Let's walk through this in detail.
 
    The JSONPath consists of "$" followed by three matchers: ".a", "[*]",
    and ".b".
 
-   Firstly, "$" matches the input document and produces a list of one
-   node: the input document.
+   Firstly, "$" matches the input document and selects the root node
+   which is the input document.  So the result is a list consisting of
+   just the root node.
 
-   Next, ".a" matches any values of input nodes (which are objects)
-   corresponding to the key ""a"".  The result is again a list of one
-   node: "[{"b":0},{"b":1},{"b":2}]".
-
-   Next, "[*]" matches all the elements of input nodes which are arrays.
-   The result is a list of three nodes: "{"b":0}", "{"b":1}", and
-   "{"b":2}".
+   Next, ".a" matches any input node of type object and selects any
+   value of the input node corresponding to the key ""a"".  The result
+   is again a list of one node: "[{"b":0},{"b":1},{"b":2}]".
 
 
 
-
-
-
-Normington               Expires 10 January 2021                [Page 4]
+Normington               Expires 15 January 2021                [Page 4]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
 
-   Finally, ".b" matches any values of input nodes (which are objects)
-   corresponding to the key ""b"".  The result is the concatenation of
-   three lists each of length one containing "0", "1", "2",
-   respectively.
+   Next, "[*]" matches any input node which is an array and selects all
+   the elements of the input node.  The result is a list of three nodes:
+   "{"b":0}", "{"b":1}", and "{"b":2}".
+
+   Finally, ".b" matches any input node of type object and selects any
+   value of the input node corresponding to the key ""b"".  The result
+   is the concatenation of three lists each of length one containing
+   "0", "1", "2", respectively.
 
    As a consequence of this approach, if any of the matchers matches no
    nodes, then the whole JSONPath matches no nodes.
 
    In what follows, the semantics of each matcher are defined for each
    type of node.
+
+2.6.  Matchers
+
+2.6.1.  Dot Child Matcher
+
+Syntax
+
+   A dot child matcher has a key known as a dot child name or a single
+   asterisk ("*").
+
+   A dot child name corresponds to a key in a JSON object, without the
+   surrounding double quotes (""").
+
+   matcher = dot-child             ; see below for alternatives
+   dot-child = %x2E dot-child-name / ; .<dot-child-name>
+               %x2E %x2A             ; .*
+   dot-child-name = TBD
+
+   More general child names, such as the empty string, are supported by
+   "Bracket Child Name" in (reference TBD).
+
+Semantics
+
+   A dot child name which is not a single asterisk ("*") matches any
+   node which is an object having a key equal to the dot child name and
+   selects the value corresponding to that key.  It does not match a
+   node which is not an object.
+
+   A dot child name consisting of a single asterisk is a wild card.  It
+   matches any node which is an object and selects all the values of the
+   object.  It also matches any node which is an array and selects all
+   the elements of the array.  It does not match a number, string, or
+   literal node.
+
+
+
+
+Normington               Expires 15 January 2021                [Page 5]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
 
 3.  IANA Considerations
 
@@ -274,14 +319,6 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
 6.2.  Informative References
 
-
-
-
-Normington               Expires 10 January 2021                [Page 5]
-
-Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
-
-
    [Goessner] Stefan Gössner, "JSONPath - XPath for JSON", February
               2007, <https://goessner.net/articles/JsonPath/>.
 
@@ -289,6 +326,17 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
               Text on Security Considerations", BCP 72, RFC 3552,
               DOI 10.17487/RFC3552, July 2003,
               <https://www.rfc-editor.org/info/rfc3552>.
+
+
+
+
+
+
+
+Normington               Expires 15 January 2021                [Page 6]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
 
    [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
               IANA Considerations Section in RFCs", RFC 5226,
@@ -333,4 +381,12 @@ Author's Address
 
 
 
-Normington               Expires 10 January 2021                [Page 6]
+
+
+
+
+
+
+
+
+Normington               Expires 15 January 2021                [Page 7]

--- a/draft-normington-jsonpath-latest.xml
+++ b/draft-normington-jsonpath-latest.xml
@@ -12,7 +12,7 @@
       submissionType="IETF"
       xml:lang="en"
       tocInclude="true"
-      tocDepth="4"
+      tocDepth="3"
       symRefs="true"
       sortRefs="true"
       version="3">
@@ -154,34 +154,70 @@ root-selector = %x24               ; $ selects document root node
          </section>
          <section numbered="true" toc="default">
             <name>Semantics</name>
-            <t>The root selector <tt>$</tt> not only selects the root node of the input document, but it produces as output a list consisting of one node: the input document.
+            <t>The root selector <tt>$</tt> not only selects the root node of the input document, but it also produces as output a list consisting of one node: the input document.
             </t>
-            <t>After the root selector, the remainder of the JSONPath passes lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
+            <t>A matcher may match a node and, if it matches, may then select zero or more descendants of the node for further processing.
+               But there's more to it than this: each matcher acts on a list of nodes and produces a list of nodes, as follows.
+            </t>
+            <t>After the root selector, the remainder of the JSONPath is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
                matching the JSONPath to the input JSON document.
             </t>
-            <t>Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher matches zero or more descendants of the node.
-               The output list of nodes of a matcher is the concatenation of the lists of matching descendents for each input node. 
+            <t>Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher may or may not match the node. If the matcher
+               matches the node, it selects zero or more descendants of the node.
+               The output list of nodes of a matcher is the concatenation of the lists of selected descendents for each input node. 
             </t>
             <t>A specific, non-normative example will make this clearer. Suppose the input document is: <tt>{"a":[{"b":0},{"b":1},{"b":2}]}</tt>. As we will see later, the JSONPath
-               <tt>$.a[*].b</tt> produces the following list of matching nodes: <tt>0</tt>, <tt>1</tt>, <tt>2</tt>. Let's walk through this in detail.
+               <tt>$.a[*].b</tt> selects the following list of nodes: <tt>0</tt>, <tt>1</tt>, <tt>2</tt>. Let's walk through this in detail.
             </t>
             <t>The JSONPath consists of <tt>$</tt> followed by three matchers: <tt>.a</tt>, <tt>[*]</tt>, and <tt>.b</tt>.
             </t>
-            <t>Firstly, <tt>$</tt> matches the input document and produces a list of one node: the input document.
+            <t>Firstly, <tt>$</tt> matches the input document and selects the root node which is the input document. So the result is a list consisting of just the root node.
             </t>
-            <t>Next, <tt>.a</tt> matches any values of input nodes (which are objects) corresponding to the key <tt>"a"</tt>.
+            <t>Next, <tt>.a</tt> matches any input node of type object and selects any value of the input node corresponding to the key <tt>"a"</tt>.
                The result is again a list of one node: <tt>[{"b":0},{"b":1},{"b":2}]</tt>.
             </t>
-            <t>Next, <tt>[*]</tt> matches all the elements of input nodes which are arrays.
+            <t>Next, <tt>[*]</tt> matches any input node which is an array and selects all the elements of the input node.
                The result is a list of three nodes: <tt>{"b":0}</tt>, <tt>{"b":1}</tt>, and <tt>{"b":2}</tt>. 
             </t>
-            <t>Finally, <tt>.b</tt> matches any values of input nodes (which are objects) corresponding to the key <tt>"b"</tt>.
+            <t>Finally, <tt>.b</tt> matches any input node of type object and selects any value of the input node corresponding to the key <tt>"b"</tt>.
                The result is the concatenation of three lists each of length one containing <tt>0</tt>, <tt>1</tt>, <tt>2</tt>, respectively.
             </t>
             <t>As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.
             </t>
             <t>In what follows, the semantics of each matcher are defined for each type of node.
             </t>
+         </section>       
+         <section numbered="true" toc="default">
+            <name>Matchers</name>
+            <section numbered="true" toc="default">
+               <name>Dot Child Matcher</name>
+               <section numbered="false" toc="default">
+                  <name>Syntax</name>
+                  <t>A dot child matcher has a key known as a dot child name or a single asterisk (<tt>*</tt>).
+                  </t>
+                  <t>A dot child name corresponds to a key in a JSON object, without the surrounding double quotes (<tt>"</tt>).
+                  </t>
+                  <sourcecode type="abnf">
+matcher = dot-child             ; see below for alternatives
+dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
+            %x2E %x2A             ; .*
+dot-child-name = TBD
+                  </sourcecode>
+                  <!-- TODO: define dot-child-name using an identifier like syntax. See https://github.com/cburgmer/json-path-comparison/issues/42 -->
+                  <t>More general child names, such as the empty string, are supported by "Bracket Child Name" in (reference TBD)<!-- <xref target="bracketchildname" format="default"/> -->.
+                  </t>
+               </section>       
+               <section numbered="false" toc="default">
+                  <name>Semantics</name>
+                  <t>A dot child name which is not a single asterisk (<tt>*</tt>) matches any node which is an object having a key equal to the dot child name
+                  and selects the value corresponding to that key.
+                  It does not match a node which is not an object.
+                  </t>
+                  <t>A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
+                     It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.
+                  </t>
+               </section>       
+            </section>       
          </section>       
    </section>
    <section anchor="IANA" numbered="true" toc="default">


### PR DESCRIPTION
See [rendered HTML](https://glyn.github.io/internet-draft/) for ease of reading.

@remorhaz: following on from the discussion in https://github.com/cburgmer/json-path-comparison/issues/42, would you care to take a crack at the grammar for `dot-child-name`? If you are up for this, please send a PR to https://github.com/glyn/internet-draft/tree/dot-child.