### PR TITLE
union child and index matchers

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1107,7 +1107,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Normington</td>
-<td class="center">Expires 18 January 2021</td>
+<td class="center">Expires 29 January 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1120,12 +1120,12 @@ dd.break {
 <dd class="internet-draft">draft-normington-jsonpath-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-17" class="published">17 July 2020</time>
+<time datetime="2020-07-28" class="published">28 July 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-01-18">18 January 2021</time></dd>
+<dd class="expires"><time datetime="2021-01-29">29 January 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -1164,7 +1164,7 @@ dd.break {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 18 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 29 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1448,33 +1448,110 @@ union-elements = union-element /
 <div id="section-2.6.2.3.1-2">
 <pre class="sourcecode lang-abnf">
 union-element = union-child ; see below for more alternatives
-union-child = %x27 *single-quoted %x27 / ; 'string'
-              %x22 *double-quoted %x22   ; "string"
+union-child = %x22 *double-quoted %x22 / ; "string"
+              %x27 *single-quoted %x27   ; 'string'
 
-single-quoted = %x5C %x27 / ; \' (escaped single quote)
-                %x5C %x5C / ; \\ (escaped reverse solidus)
-                %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
-                            ; any Unicode code point except ' or \
+double-quoted = dq-unescaped /
+          escape (
+              %x22 /          ; "    quotation mark  U+0022
+              %x2F /          ; /    solidus         U+002F
+              %x5C /          ; \    reverse solidus U+005C
+              %x62 /          ; b    backspace       U+0008
+              %x66 /          ; f    form feed       U+000C
+              %x6E /          ; n    line feed       U+000A
+              %x72 /          ; r    carriage return U+000D
+              %x74 /          ; t    tab             U+0009
+              %x75 4HEXDIG )  ; uXXXX                U+XXXX
 
-double-quoted = %x5C 5x22 / ; \" (escaped double quote)
-                %x5C 5x5C / ; \\ (escaped reverse solidus)
-                %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
-                            ; any Unicode code point except " or \
+
+      dq-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+
+single-quoted = sq-unescaped /
+          escape (
+              %x27 /          ; '    apostrophe      U+0027
+              %x2F /          ; /    solidus         U+002F
+              %x5C /          ; \    reverse solidus U+005C
+              %x62 /          ; b    backspace       U+0008
+              %x66 /          ; f    form feed       U+000C
+              %x6E /          ; n    line feed       U+000A
+              %x72 /          ; r    carriage return U+000D
+              %x74 /          ; t    tab             U+0009
+              %x75 4HEXDIG )  ; uXXXX                U+XXXX
+
+      sq-unescaped = %x20-26 / %x28-5B / %x5D-10FFFF
+
+escape = %x5C                 ; \
+
+HEXDIG =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+DIGIT =  %x30-39              ; 0-9
 </pre><a href="#section-2.6.2.3.1-2" class="pilcrow">¶</a>
 </div>
-<p id="section-2.6.2.3.1-3">Note: the syntax does not allow any character other than a quote or reverse solidus to be escaped.<a href="#section-2.6.2.3.1-3" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.3.1-3">Note: double-quoted strings follow JSON in <span><a href="#RFC8259" class="xref">RFC 8259</a> [<a href="#RFC8259" class="xref">RFC8259</a>]</span>.
+                        Single-quoted strings follow an analogous pattern.<a href="#section-2.6.2.3.1-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6.2.3.2">
               <h6 id="name-semantics-9">
 <a href="#name-semantics-9" class="section-name selfRef">Semantics</a>
               </h6>
-<p id="section-2.6.2.3.2-1">If the union child is a quoted string, the string must first have the surrounding quotes removed and then be unescaped
-                        as describe below.
-                        The union child matches any node which is an object having a key equal to the unescaped value of the union child string
-                        and selects the value corresponding to that key.
-                        It does not match a node which is not an object.<a href="#section-2.6.2.3.2-1" class="pilcrow">¶</a></p>
-<p id="section-2.6.2.3.2-2">After the surrounding quotes have been removed, a string is unescaped by replacing each escaped quote by the corresponding
-                        quote and replacing each escaped reverse solidus by a reverse solidus.<a href="#section-2.6.2.3.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.3.2-1">If the union child is a quoted string, the string MUST be converted to a key by removing the surrounding quotes and
+                        replacing each escape sequence with its equivalent Unicode character, as in the table below:<a href="#section-2.6.2.3.2-1" class="pilcrow">¶</a></p>
+<span id="name-escape-sequence-replacements"></span><table class="center" id="table-1">
+                <caption>
+<a href="#table-1" class="selfRef">Table 1</a>:
+<a href="#name-escape-sequence-replacements" class="selfRef">Escape Sequence Replacements</a>
+                </caption>
+<thead>
+                  <tr>
+                    <th class="text-center" rowspan="1" colspan="1">Escape Sequence</th>
+                    <th class="text-center" rowspan="1" colspan="1">Unicode Character</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x22</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0022</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x27</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0027</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x2F</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+002F</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x5C</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+005C</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x62</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0008</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x66</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+000C</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x6E</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+000A</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x72</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+000D</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x74</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0009</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C uXXXX</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+XXXX</td>
+                  </tr>
+                </tbody>
+              </table>
+<p id="section-2.6.2.3.2-3">
+                        The union child matches any node which is an object with this key and selects the value corresponding to the key.
+                        It does not match a node which is not an object.<a href="#section-2.6.2.3.2-3" class="pilcrow">¶</a></p>
 </section>
 </section>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
 <title>JavaScript Object Notation (JSON) Path</title>
 <meta content="Glyn Normington" name="author">
 <meta content="
-       JSONPath defines a string syntax for identifying values
+       JSON Path defines a string syntax for identifying values
    within a JavaScript Object Notation (JSON) document. 
     " name="description">
 <meta content="xml2rfc 2.44.0" name="generator">
@@ -1107,7 +1107,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Normington</td>
-<td class="center">Expires 15 January 2021</td>
+<td class="center">Expires 18 January 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1120,12 +1120,12 @@ dd.break {
 <dd class="internet-draft">draft-normington-jsonpath-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-14" class="published">14 July 2020</time>
+<time datetime="2020-07-17" class="published">17 July 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-01-15">15 January 2021</time></dd>
+<dd class="expires"><time datetime="2021-01-18">18 January 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -1139,7 +1139,7 @@ dd.break {
 <h1 id="title">JavaScript Object Notation (JSON) Path</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
-<p id="section-abstract-1">JSONPath defines a string syntax for identifying values
+<p id="section-abstract-1">JSON Path defines a string syntax for identifying values
    within a JavaScript Object Notation (JSON) document.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 </section>
 <section class="note" id="section-note.1">
@@ -1164,7 +1164,7 @@ dd.break {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 15 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 18 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1205,7 +1205,7 @@ dd.break {
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-jsonpath-syntax-and-semantic" class="xref">JSONPath Syntax and Semantics</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-json-path-syntax-and-semanti" class="xref">JSON Path Syntax and Semantics</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.1">
                 <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-overview-2" class="xref">Overview</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
@@ -1217,16 +1217,33 @@ dd.break {
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-implementation-2" class="xref">Implementation</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
-                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-3" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-6" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.5">
-                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-3" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-6" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.6">
                 <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="xref">2.6</a>.  <a href="#name-matchers-2" class="xref">Matchers</a><a href="#section-toc.1-1.2.2.6.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.1">
                     <p id="section-toc.1-1.2.2.6.2.1.1"><a href="#section-2.6.1" class="xref">2.6.1</a>.  <a href="#name-dot-child-matcher-2" class="xref">Dot Child Matcher</a><a href="#section-toc.1-1.2.2.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2">
+                    <p id="section-toc.1-1.2.2.6.2.2.1"><a href="#section-2.6.2" class="xref">2.6.2</a>.  <a href="#name-union-matcher-2" class="xref">Union Matcher</a><a href="#section-toc.1-1.2.2.6.2.2.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.1">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.1.1"><a href="#section-2.6.2.1" class="xref">2.6.2.1</a>.  <a href="#name-syntax-8" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.6.2.2.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.2">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.2.1"><a href="#section-2.6.2.2" class="xref">2.6.2.2</a>.  <a href="#name-semantics-8" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.6.2.2.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.3">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.3.1"><a href="#section-2.6.2.3" class="xref">2.6.2.3</a>.  <a href="#name-union-child-2" class="xref">Union Child</a><a href="#section-toc.1-1.2.2.6.2.2.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.4">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.4.1"><a href="#section-2.6.2.4" class="xref">2.6.2.4</a>.  <a href="#name-array-index-2" class="xref">Array Index</a><a href="#section-toc.1-1.2.2.6.2.2.2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 </ul>
 </li>
@@ -1263,7 +1280,7 @@ dd.break {
       <h2 id="name-introduction-2">
 <a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction-2" class="section-name selfRef">Introduction</a>
       </h2>
-<p id="section-1-1">JSONPath was introduced by Stefan Goessner as a simple form of XPath for JSON.
+<p id="section-1-1">JSON Path, or rather JSONPath, was introduced by Stefan Goessner as a simple form of XPath for JSON.
          See his original article <span>[<a href="#Goessner" class="xref">Goessner</a>]</span>.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <p id="section-1-2">JSON is defined by <span><a href="#RFC8259" class="xref">RFC 8259</a> [<a href="#RFC8259" class="xref">RFC8259</a>]</span>.<a href="#section-1-2" class="pilcrow">¶</a></p>
 <section id="section-1.1">
@@ -1279,17 +1296,21 @@ dd.break {
 <a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-abnf-syntax-2" class="section-name selfRef">ABNF Syntax</a>
         </h3>
 <p id="section-1.2-1">The syntax in this document conforms to ABNF as defined by <span><a href="#RFC5234" class="xref">RFC 5234</a> [<a href="#RFC5234" class="xref">RFC5234</a>]</span>.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+<p id="section-1.2-2">ABNF terminal values in this document define Unicode code points rather than their UTF-8 encoding.
+           For example, the Unicode PLACE OF INTEREST SIGN (U+2318) would be defined in ABNF as <code>%x2318</code>.<a href="#section-1.2-2" class="pilcrow">¶</a></p>
 </section>
 </section>
 <section id="section-2">
-      <h2 id="name-jsonpath-syntax-and-semantic">
-<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-jsonpath-syntax-and-semantic" class="section-name selfRef">JSONPath Syntax and Semantics</a>
+      <h2 id="name-json-path-syntax-and-semanti">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-json-path-syntax-and-semanti" class="section-name selfRef">JSON Path Syntax and Semantics</a>
       </h2>
 <section id="section-2.1">
         <h3 id="name-overview-2">
 <a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-overview-2" class="section-name selfRef">Overview</a>
         </h3>
-<p id="section-2.1-1">A JSONPath is a string which matches zero or more nodes of any JSON document. A valid JSONPath conforms to the ABNF syntax defined by this document.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-1">A JSON Path is a string which matches zero or more nodes of any JSON document. A valid JSON Path conforms to the ABNF syntax defined by this document.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-2">A JSON Path MUST be encoded using UTF-8. To parse a JSON Path according to the grammar in this document, its UTF-8 form SHOULD first be decoded into Unicode code points as described
+               in <span><a href="#RFC3629" class="xref">RFC 3629</a> [<a href="#RFC3629" class="xref">RFC3629</a>]</span>.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.2">
         <h3 id="name-terminology-2">
@@ -1304,21 +1325,21 @@ dd.break {
         <h3 id="name-implementation-2">
 <a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-implementation-2" class="section-name selfRef">Implementation</a>
         </h3>
-<p id="section-2.3-1">An implementation of this specification, from now on referred to simply as "an implementation", SHOULD takes two inputs, a JSONPath and a JSON document, and produce
-               a possibly empty list of nodes of the JSON document which match the JSONPath or an error (but not both).<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3-1">An implementation of this specification, from now on referred to simply as "an implementation", SHOULD takes two inputs, a JSON Path and a JSON document, and produce
+               a possibly empty list of nodes of the JSON document which match the JSON Path or an error (but not both).<a href="#section-2.3-1" class="pilcrow">¶</a></p>
 <p id="section-2.3-2">If there is no matching node and no error has occurred, an implementation MUST return an empty list of nodes.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
-<p id="section-2.3-3">Syntax errors in the JSONPath SHOULD be detected before matching is attempted since they do not depend on the JSON document.
-               Therefore, an implementation SHOULD take a JSONPath and produce an optional syntax error and then,
+<p id="section-2.3-3">Syntax errors in the JSON Path SHOULD be detected before matching is attempted since they do not depend on the JSON document.
+               Therefore, an implementation SHOULD take a JSON Path and produce an optional syntax error and then,
                if and only if an error was not produced, SHOULD take a JSON document and produce a list of matches or an error (but not both).<a href="#section-2.3-3" class="pilcrow">¶</a></p>
-<p id="section-2.3-4">Alternatively, an implementation MAY take a JSONPath and a JSON document and produce a list of matches or an optional error (but not both).<a href="#section-2.3-4" class="pilcrow">¶</a></p>
-<p id="section-2.3-5">For any implementation, if a syntactically invalid JSONPath is provided, the implementation MUST return an error.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
+<p id="section-2.3-4">Alternatively, an implementation MAY take a JSON Path and a JSON document and produce a list of matches or an optional error (but not both).<a href="#section-2.3-4" class="pilcrow">¶</a></p>
+<p id="section-2.3-5">For any implementation, if a syntactically invalid JSON Path is provided, the implementation MUST return an error.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
 <p id="section-2.3-6">If a syntactially invalid JSON document is provided, any implementation SHOULD return an error.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.4">
-        <h3 id="name-syntax-3">
-<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-3" class="section-name selfRef">Syntax</a>
+        <h3 id="name-syntax-6">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-6" class="section-name selfRef">Syntax</a>
         </h3>
-<p id="section-2.4-1">Syntactically, a JSONPath consists of a root selector (<code>$</code>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-1">Syntactically, a JSON Path consists of a root selector (<code>$</code>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
 <div id="section-2.4-2">
 <pre class="sourcecode lang-abnf">
 json-path = root-selector *matcher
@@ -1328,20 +1349,20 @@ root-selector = %x24               ; $ selects document root node
 <p id="section-2.4-3">The syntax and semantics of each matcher is defined below.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.5">
-        <h3 id="name-semantics-3">
-<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-3" class="section-name selfRef">Semantics</a>
+        <h3 id="name-semantics-6">
+<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-6" class="section-name selfRef">Semantics</a>
         </h3>
 <p id="section-2.5-1">The root selector <code>$</code> not only selects the root node of the input document, but it also produces as output a list consisting of one node: the input document.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
 <p id="section-2.5-2">A matcher may match a node and, if it matches, may then select zero or more descendants of the node for further processing.
                But there's more to it than this: each matcher acts on a list of nodes and produces a list of nodes, as follows.<a href="#section-2.5-2" class="pilcrow">¶</a></p>
-<p id="section-2.5-3">After the root selector, the remainder of the JSONPath is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
-               matching the JSONPath to the input JSON document.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
+<p id="section-2.5-3">After the root selector, the remainder of the JSON Path is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
+               matching the JSON Path to the input JSON document.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
 <p id="section-2.5-4">Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher may or may not match the node. If the matcher
                matches the node, it selects zero or more descendants of the node.
                The output list of nodes of a matcher is the concatenation of the lists of selected descendents for each input node.<a href="#section-2.5-4" class="pilcrow">¶</a></p>
-<p id="section-2.5-5">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSONPath
+<p id="section-2.5-5">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSON Path
                <code>$.a[*].b</code> selects the following list of nodes: <code>0</code>, <code>1</code>, <code>2</code>. Let's walk through this in detail.<a href="#section-2.5-5" class="pilcrow">¶</a></p>
-<p id="section-2.5-6">The JSONPath consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
+<p id="section-2.5-6">The JSON Path consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
 <p id="section-2.5-7">Firstly, <code>$</code> matches the input document and selects the root node which is the input document. So the result is a list consisting of just the root node.<a href="#section-2.5-7" class="pilcrow">¶</a></p>
 <p id="section-2.5-8">Next, <code>.a</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"a"</code>.
                The result is again a list of one node: <code>[{"b":0},{"b":1},{"b":2}]</code>.<a href="#section-2.5-8" class="pilcrow">¶</a></p>
@@ -1349,7 +1370,7 @@ root-selector = %x24               ; $ selects document root node
                The result is a list of three nodes: <code>{"b":0}</code>, <code>{"b":1}</code>, and <code>{"b":2}</code>.<a href="#section-2.5-9" class="pilcrow">¶</a></p>
 <p id="section-2.5-10">Finally, <code>.b</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"b"</code>.
                The result is the concatenation of three lists each of length one containing <code>0</code>, <code>1</code>, <code>2</code>, respectively.<a href="#section-2.5-10" class="pilcrow">¶</a></p>
-<p id="section-2.5-11">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
+<p id="section-2.5-11">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSON Path matches no nodes.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
 <p id="section-2.5-12">In what follows, the semantics of each matcher are defined for each type of node.<a href="#section-2.5-12" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6">
@@ -1361,8 +1382,8 @@ root-selector = %x24               ; $ selects document root node
 <a href="#section-2.6.1" class="section-number selfRef">2.6.1. </a><a href="#name-dot-child-matcher-2" class="section-name selfRef">Dot Child Matcher</a>
           </h4>
 <section id="section-2.6.1.1">
-            <h5 id="name-syntax-4">
-<a href="#name-syntax-4" class="section-name selfRef">Syntax</a>
+            <h5 id="name-syntax-7">
+<a href="#name-syntax-7" class="section-name selfRef">Syntax</a>
             </h5>
 <p id="section-2.6.1.1-1">A dot child matcher has a key known as a dot child name or a single asterisk (<code>*</code>).<a href="#section-2.6.1.1-1" class="pilcrow">¶</a></p>
 <p id="section-2.6.1.1-2">A dot child name corresponds to a key in a JSON object, without the surrounding double quotes (<code>"</code>).<a href="#section-2.6.1.1-2" class="pilcrow">¶</a></p>
@@ -1374,17 +1395,120 @@ dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
 dot-child-name = TBD
 </pre><a href="#section-2.6.1.1-3" class="pilcrow">¶</a>
 </div>
-<p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Bracket Child Name" in (reference TBD).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Union Child" (<a href="#unionchild" class="xref">Section 2.6.2.3</a>).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6.1.2">
-            <h5 id="name-semantics-4">
-<a href="#name-semantics-4" class="section-name selfRef">Semantics</a>
+            <h5 id="name-semantics-7">
+<a href="#name-semantics-7" class="section-name selfRef">Semantics</a>
             </h5>
 <p id="section-2.6.1.2-1">A dot child name which is not a single asterisk (<code>*</code>) matches any node which is an object having a key equal to the dot child name
                   and selects the value corresponding to that key.
                   It does not match a node which is not an object.<a href="#section-2.6.1.2-1" class="pilcrow">¶</a></p>
 <p id="section-2.6.1.2-2">A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
                      It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
+</section>
+</section>
+<section id="section-2.6.2">
+          <h4 id="name-union-matcher-2">
+<a href="#section-2.6.2" class="section-number selfRef">2.6.2. </a><a href="#name-union-matcher-2" class="section-name selfRef">Union Matcher</a>
+          </h4>
+<section id="section-2.6.2.1">
+            <h5 id="name-syntax-8">
+<a href="#section-2.6.2.1" class="section-number selfRef">2.6.2.1. </a><a href="#name-syntax-8" class="section-name selfRef">Syntax</a>
+            </h5>
+<p id="section-2.6.2.1-1">A union matcher consists of one or more union elements.<a href="#section-2.6.2.1-1" class="pilcrow">¶</a></p>
+<div id="section-2.6.2.1-2">
+<pre class="sourcecode lang-abnf">
+matcher =/ union
+union = %x5B ws union-elements ws %x5D ; [...]
+ws = *%x20                             ; zero or more spaces
+union-elements = union-element /
+                 union-element ws %x2C ws union-elements
+                                       ; ,-separated list
+</pre><a href="#section-2.6.2.1-2" class="pilcrow">¶</a>
+</div>
+</section>
+<section id="section-2.6.2.2">
+            <h5 id="name-semantics-8">
+<a href="#section-2.6.2.2" class="section-number selfRef">2.6.2.2. </a><a href="#name-semantics-8" class="section-name selfRef">Semantics</a>
+            </h5>
+<p id="section-2.6.2.2-1">A union matches any node which is matched by at least one of the union elements and selects the concatenation of the
+                     lists (in the order of the matchers) of descendants selected by the union elements.<a href="#section-2.6.2.2-1" class="pilcrow">¶</a></p>
+</section>
+<div id="unionchild">
+<section id="section-2.6.2.3">
+            <h5 id="name-union-child-2">
+<a href="#section-2.6.2.3" class="section-number selfRef">2.6.2.3. </a><a href="#name-union-child-2" class="section-name selfRef">Union Child</a>
+            </h5>
+<section id="section-2.6.2.3.1">
+              <h6 id="name-syntax-9">
+<a href="#name-syntax-9" class="section-name selfRef">Syntax</a>
+              </h6>
+<p id="section-2.6.2.3.1-1">A union child is a union element consisting of a quoted string.<a href="#section-2.6.2.3.1-1" class="pilcrow">¶</a></p>
+<div id="section-2.6.2.3.1-2">
+<pre class="sourcecode lang-abnf">
+union-element = union-child ; see below for more alternatives
+union-child = %x27 *single-quoted %x27 / ; 'string'
+              %x22 *double-quoted %x22   ; "string"
+
+single-quoted = %x5C %x27 / ; \' (escaped single quote)
+                %x5C %x5C / ; \\ (escaped reverse solidus)
+                %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
+                            ; any Unicode code point except ' or \
+
+double-quoted = %x5C 5x22 / ; \" (escaped double quote)
+                %x5C 5x5C / ; \\ (escaped reverse solidus)
+                %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
+                            ; any Unicode code point except " or \
+</pre><a href="#section-2.6.2.3.1-2" class="pilcrow">¶</a>
+</div>
+<p id="section-2.6.2.3.1-3">Note: the syntax does not allow any character other than a quote or reverse solidus to be escaped.<a href="#section-2.6.2.3.1-3" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6.2.3.2">
+              <h6 id="name-semantics-9">
+<a href="#name-semantics-9" class="section-name selfRef">Semantics</a>
+              </h6>
+<p id="section-2.6.2.3.2-1">If the union child is a quoted string, the string must first have the surrounding quotes removed and then be unescaped
+                        as describe below.
+                        The union child matches any node which is an object having a key equal to the unescaped value of the union child string
+                        and selects the value corresponding to that key.
+                        It does not match a node which is not an object.<a href="#section-2.6.2.3.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.3.2-2">After the surrounding quotes have been removed, a string is unescaped by replacing each escaped quote by the corresponding
+                        quote and replacing each escaped reverse solidus by a reverse solidus.<a href="#section-2.6.2.3.2-2" class="pilcrow">¶</a></p>
+</section>
+</section>
+</div>
+<section id="section-2.6.2.4">
+            <h5 id="name-array-index-2">
+<a href="#section-2.6.2.4" class="section-number selfRef">2.6.2.4. </a><a href="#name-array-index-2" class="section-name selfRef">Array Index</a>
+            </h5>
+<section id="section-2.6.2.4.1">
+              <h6 id="name-syntax-10">
+<a href="#name-syntax-10" class="section-name selfRef">Syntax</a>
+              </h6>
+<p id="section-2.6.2.4.1-1">An array index is a union element consisting of an integer (in base 10).<a href="#section-2.6.2.4.1-1" class="pilcrow">¶</a></p>
+<div id="section-2.6.2.4.1-2">
+<pre class="sourcecode lang-abnf">
+union-element =/ integer
+integer = [%x2D] (%x30 / (%x31-39 *%x30-39))
+                            ; optional - followed by 0 or
+                            ; sequence of digits with no leading zero
+</pre><a href="#section-2.6.2.4.1-2" class="pilcrow">¶</a>
+</div>
+<p id="section-2.6.2.4.1-3">Note: the syntax does not allow integers with leading zeros such as <code>01</code> and <code>-01</code>.<a href="#section-2.6.2.4.1-3" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6.2.4.2">
+              <h6 id="name-semantics-10">
+<a href="#name-semantics-10" class="section-name selfRef">Semantics</a>
+              </h6>
+<p id="section-2.6.2.4.2-1">An array index matches any node which is an array and selects any element of the array indexed by the integer index.
+                        It does not match a node which is not an array.<a href="#section-2.6.2.4.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.4.2-2">A non-negative index <code>i</code> selects an element of an array of length <code>len</code> if and only if <code>0 &lt;= i &lt; len</code>.
+                        The index <code>0</code> selects the first element of a non-empty array and, providing <code>i &lt; len - 1</code>, index <code>i + 1</code>
+                        selects the element immedately after (in array order) the element selected by index <code>i</code>.<a href="#section-2.6.2.4.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.4.2-3">A negative index <code>j</code> selects an element of an array of length <code>len</code> if and only if <code>0 &lt;= j + len &lt; len</code>,
+                        in which case it selects the same element as selected by the non-negative index <code>j + len</code>.<a href="#section-2.6.2.4.2-3" class="pilcrow">¶</a></p>
+</section>
 </section>
 </section>
 </section>
@@ -1430,6 +1554,10 @@ dot-child-name = TBD
 <dt id="RFC2119">[RFC2119]</dt>
 <dd>
 <span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC3629">[RFC3629]</dt>
+<dd>
+<span class="refAuthor">Yergeau, F.</span>, <span class="refTitle">"UTF-8, a transformation format of ISO 10646"</span>, <span class="seriesInfo">STD 63</span>, <span class="seriesInfo">RFC 3629</span>, <span class="seriesInfo">DOI 10.17487/RFC3629</span>, <time datetime="2003-11">November 2003</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3629">https://www.rfc-editor.org/info/rfc3629</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC5234">[RFC5234]</dt>
 <dd>

--- a/draft-normington-jsonpath-latest.html
+++ b/draft-normington-jsonpath-latest.html
@@ -1107,7 +1107,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Normington</td>
-<td class="center">Expires 18 January 2021</td>
+<td class="center">Expires 29 January 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1120,12 +1120,12 @@ dd.break {
 <dd class="internet-draft">draft-normington-jsonpath-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-17" class="published">17 July 2020</time>
+<time datetime="2020-07-28" class="published">28 July 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-01-18">18 January 2021</time></dd>
+<dd class="expires"><time datetime="2021-01-29">29 January 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -1164,7 +1164,7 @@ dd.break {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 18 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 29 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1448,33 +1448,110 @@ union-elements = union-element /
 <div id="section-2.6.2.3.1-2">
 <pre class="sourcecode lang-abnf">
 union-element = union-child ; see below for more alternatives
-union-child = %x27 *single-quoted %x27 / ; 'string'
-              %x22 *double-quoted %x22   ; "string"
+union-child = %x22 *double-quoted %x22 / ; "string"
+              %x27 *single-quoted %x27   ; 'string'
 
-single-quoted = %x5C %x27 / ; \' (escaped single quote)
-                %x5C %x5C / ; \\ (escaped reverse solidus)
-                %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
-                            ; any Unicode code point except ' or \
+double-quoted = dq-unescaped /
+          escape (
+              %x22 /          ; "    quotation mark  U+0022
+              %x2F /          ; /    solidus         U+002F
+              %x5C /          ; \    reverse solidus U+005C
+              %x62 /          ; b    backspace       U+0008
+              %x66 /          ; f    form feed       U+000C
+              %x6E /          ; n    line feed       U+000A
+              %x72 /          ; r    carriage return U+000D
+              %x74 /          ; t    tab             U+0009
+              %x75 4HEXDIG )  ; uXXXX                U+XXXX
 
-double-quoted = %x5C 5x22 / ; \" (escaped double quote)
-                %x5C 5x5C / ; \\ (escaped reverse solidus)
-                %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
-                            ; any Unicode code point except " or \
+
+      dq-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+
+single-quoted = sq-unescaped /
+          escape (
+              %x27 /          ; '    apostrophe      U+0027
+              %x2F /          ; /    solidus         U+002F
+              %x5C /          ; \    reverse solidus U+005C
+              %x62 /          ; b    backspace       U+0008
+              %x66 /          ; f    form feed       U+000C
+              %x6E /          ; n    line feed       U+000A
+              %x72 /          ; r    carriage return U+000D
+              %x74 /          ; t    tab             U+0009
+              %x75 4HEXDIG )  ; uXXXX                U+XXXX
+
+      sq-unescaped = %x20-26 / %x28-5B / %x5D-10FFFF
+
+escape = %x5C                 ; \
+
+HEXDIG =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+DIGIT =  %x30-39              ; 0-9
 </pre><a href="#section-2.6.2.3.1-2" class="pilcrow">¶</a>
 </div>
-<p id="section-2.6.2.3.1-3">Note: the syntax does not allow any character other than a quote or reverse solidus to be escaped.<a href="#section-2.6.2.3.1-3" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.3.1-3">Note: double-quoted strings follow JSON in <span><a href="#RFC8259" class="xref">RFC 8259</a> [<a href="#RFC8259" class="xref">RFC8259</a>]</span>.
+                        Single-quoted strings follow an analogous pattern.<a href="#section-2.6.2.3.1-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6.2.3.2">
               <h6 id="name-semantics-9">
 <a href="#name-semantics-9" class="section-name selfRef">Semantics</a>
               </h6>
-<p id="section-2.6.2.3.2-1">If the union child is a quoted string, the string must first have the surrounding quotes removed and then be unescaped
-                        as describe below.
-                        The union child matches any node which is an object having a key equal to the unescaped value of the union child string
-                        and selects the value corresponding to that key.
-                        It does not match a node which is not an object.<a href="#section-2.6.2.3.2-1" class="pilcrow">¶</a></p>
-<p id="section-2.6.2.3.2-2">After the surrounding quotes have been removed, a string is unescaped by replacing each escaped quote by the corresponding
-                        quote and replacing each escaped reverse solidus by a reverse solidus.<a href="#section-2.6.2.3.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.3.2-1">If the union child is a quoted string, the string MUST be converted to a key by removing the surrounding quotes and
+                        replacing each escape sequence with its equivalent Unicode character, as in the table below:<a href="#section-2.6.2.3.2-1" class="pilcrow">¶</a></p>
+<span id="name-escape-sequence-replacements"></span><table class="center" id="table-1">
+                <caption>
+<a href="#table-1" class="selfRef">Table 1</a>:
+<a href="#name-escape-sequence-replacements" class="selfRef">Escape Sequence Replacements</a>
+                </caption>
+<thead>
+                  <tr>
+                    <th class="text-center" rowspan="1" colspan="1">Escape Sequence</th>
+                    <th class="text-center" rowspan="1" colspan="1">Unicode Character</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x22</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0022</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x27</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0027</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x2F</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+002F</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x5C</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+005C</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x62</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0008</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x66</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+000C</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x6E</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+000A</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x72</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+000D</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C %x74</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+0009</td>
+                  </tr>
+                  <tr>
+                    <td class="text-center" rowspan="1" colspan="1">%x5C uXXXX</td>
+                    <td class="text-center" rowspan="1" colspan="1">U+XXXX</td>
+                  </tr>
+                </tbody>
+              </table>
+<p id="section-2.6.2.3.2-3">
+                        The union child matches any node which is an object with this key and selects the value corresponding to the key.
+                        It does not match a node which is not an object.<a href="#section-2.6.2.3.2-3" class="pilcrow">¶</a></p>
 </section>
 </section>
 </div>

--- a/draft-normington-jsonpath-latest.html
+++ b/draft-normington-jsonpath-latest.html
@@ -7,7 +7,7 @@
 <title>JavaScript Object Notation (JSON) Path</title>
 <meta content="Glyn Normington" name="author">
 <meta content="
-       JSONPath defines a string syntax for identifying values
+       JSON Path defines a string syntax for identifying values
    within a JavaScript Object Notation (JSON) document. 
     " name="description">
 <meta content="xml2rfc 2.44.0" name="generator">
@@ -1107,7 +1107,7 @@ dd.break {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Normington</td>
-<td class="center">Expires 15 January 2021</td>
+<td class="center">Expires 18 January 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1120,12 +1120,12 @@ dd.break {
 <dd class="internet-draft">draft-normington-jsonpath-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-14" class="published">14 July 2020</time>
+<time datetime="2020-07-17" class="published">17 July 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-01-15">15 January 2021</time></dd>
+<dd class="expires"><time datetime="2021-01-18">18 January 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -1139,7 +1139,7 @@ dd.break {
 <h1 id="title">JavaScript Object Notation (JSON) Path</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
-<p id="section-abstract-1">JSONPath defines a string syntax for identifying values
+<p id="section-abstract-1">JSON Path defines a string syntax for identifying values
    within a JavaScript Object Notation (JSON) document.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 </section>
 <section class="note" id="section-note.1">
@@ -1164,7 +1164,7 @@ dd.break {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 15 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 18 January 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1205,7 +1205,7 @@ dd.break {
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-jsonpath-syntax-and-semantic" class="xref">JSONPath Syntax and Semantics</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-json-path-syntax-and-semanti" class="xref">JSON Path Syntax and Semantics</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.1">
                 <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-overview-2" class="xref">Overview</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
@@ -1217,16 +1217,33 @@ dd.break {
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-implementation-2" class="xref">Implementation</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
-                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-3" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-6" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.5">
-                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-3" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-6" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.6">
                 <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="xref">2.6</a>.  <a href="#name-matchers-2" class="xref">Matchers</a><a href="#section-toc.1-1.2.2.6.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.1">
                     <p id="section-toc.1-1.2.2.6.2.1.1"><a href="#section-2.6.1" class="xref">2.6.1</a>.  <a href="#name-dot-child-matcher-2" class="xref">Dot Child Matcher</a><a href="#section-toc.1-1.2.2.6.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2">
+                    <p id="section-toc.1-1.2.2.6.2.2.1"><a href="#section-2.6.2" class="xref">2.6.2</a>.  <a href="#name-union-matcher-2" class="xref">Union Matcher</a><a href="#section-toc.1-1.2.2.6.2.2.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.1">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.1.1"><a href="#section-2.6.2.1" class="xref">2.6.2.1</a>.  <a href="#name-syntax-8" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.6.2.2.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.2">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.2.1"><a href="#section-2.6.2.2" class="xref">2.6.2.2</a>.  <a href="#name-semantics-8" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.6.2.2.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.3">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.3.1"><a href="#section-2.6.2.3" class="xref">2.6.2.3</a>.  <a href="#name-union-child-2" class="xref">Union Child</a><a href="#section-toc.1-1.2.2.6.2.2.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6.2.2.2.4">
+                        <p id="section-toc.1-1.2.2.6.2.2.2.4.1"><a href="#section-2.6.2.4" class="xref">2.6.2.4</a>.  <a href="#name-array-index-2" class="xref">Array Index</a><a href="#section-toc.1-1.2.2.6.2.2.2.4.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
 </li>
 </ul>
 </li>
@@ -1263,7 +1280,7 @@ dd.break {
       <h2 id="name-introduction-2">
 <a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction-2" class="section-name selfRef">Introduction</a>
       </h2>
-<p id="section-1-1">JSONPath was introduced by Stefan Goessner as a simple form of XPath for JSON.
+<p id="section-1-1">JSON Path, or rather JSONPath, was introduced by Stefan Goessner as a simple form of XPath for JSON.
          See his original article <span>[<a href="#Goessner" class="xref">Goessner</a>]</span>.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <p id="section-1-2">JSON is defined by <span><a href="#RFC8259" class="xref">RFC 8259</a> [<a href="#RFC8259" class="xref">RFC8259</a>]</span>.<a href="#section-1-2" class="pilcrow">¶</a></p>
 <section id="section-1.1">
@@ -1279,17 +1296,21 @@ dd.break {
 <a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-abnf-syntax-2" class="section-name selfRef">ABNF Syntax</a>
         </h3>
 <p id="section-1.2-1">The syntax in this document conforms to ABNF as defined by <span><a href="#RFC5234" class="xref">RFC 5234</a> [<a href="#RFC5234" class="xref">RFC5234</a>]</span>.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+<p id="section-1.2-2">ABNF terminal values in this document define Unicode code points rather than their UTF-8 encoding.
+           For example, the Unicode PLACE OF INTEREST SIGN (U+2318) would be defined in ABNF as <code>%x2318</code>.<a href="#section-1.2-2" class="pilcrow">¶</a></p>
 </section>
 </section>
 <section id="section-2">
-      <h2 id="name-jsonpath-syntax-and-semantic">
-<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-jsonpath-syntax-and-semantic" class="section-name selfRef">JSONPath Syntax and Semantics</a>
+      <h2 id="name-json-path-syntax-and-semanti">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-json-path-syntax-and-semanti" class="section-name selfRef">JSON Path Syntax and Semantics</a>
       </h2>
 <section id="section-2.1">
         <h3 id="name-overview-2">
 <a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-overview-2" class="section-name selfRef">Overview</a>
         </h3>
-<p id="section-2.1-1">A JSONPath is a string which matches zero or more nodes of any JSON document. A valid JSONPath conforms to the ABNF syntax defined by this document.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-1">A JSON Path is a string which matches zero or more nodes of any JSON document. A valid JSON Path conforms to the ABNF syntax defined by this document.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-2">A JSON Path MUST be encoded using UTF-8. To parse a JSON Path according to the grammar in this document, its UTF-8 form SHOULD first be decoded into Unicode code points as described
+               in <span><a href="#RFC3629" class="xref">RFC 3629</a> [<a href="#RFC3629" class="xref">RFC3629</a>]</span>.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.2">
         <h3 id="name-terminology-2">
@@ -1304,21 +1325,21 @@ dd.break {
         <h3 id="name-implementation-2">
 <a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-implementation-2" class="section-name selfRef">Implementation</a>
         </h3>
-<p id="section-2.3-1">An implementation of this specification, from now on referred to simply as "an implementation", SHOULD takes two inputs, a JSONPath and a JSON document, and produce
-               a possibly empty list of nodes of the JSON document which match the JSONPath or an error (but not both).<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3-1">An implementation of this specification, from now on referred to simply as "an implementation", SHOULD takes two inputs, a JSON Path and a JSON document, and produce
+               a possibly empty list of nodes of the JSON document which match the JSON Path or an error (but not both).<a href="#section-2.3-1" class="pilcrow">¶</a></p>
 <p id="section-2.3-2">If there is no matching node and no error has occurred, an implementation MUST return an empty list of nodes.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
-<p id="section-2.3-3">Syntax errors in the JSONPath SHOULD be detected before matching is attempted since they do not depend on the JSON document.
-               Therefore, an implementation SHOULD take a JSONPath and produce an optional syntax error and then,
+<p id="section-2.3-3">Syntax errors in the JSON Path SHOULD be detected before matching is attempted since they do not depend on the JSON document.
+               Therefore, an implementation SHOULD take a JSON Path and produce an optional syntax error and then,
                if and only if an error was not produced, SHOULD take a JSON document and produce a list of matches or an error (but not both).<a href="#section-2.3-3" class="pilcrow">¶</a></p>
-<p id="section-2.3-4">Alternatively, an implementation MAY take a JSONPath and a JSON document and produce a list of matches or an optional error (but not both).<a href="#section-2.3-4" class="pilcrow">¶</a></p>
-<p id="section-2.3-5">For any implementation, if a syntactically invalid JSONPath is provided, the implementation MUST return an error.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
+<p id="section-2.3-4">Alternatively, an implementation MAY take a JSON Path and a JSON document and produce a list of matches or an optional error (but not both).<a href="#section-2.3-4" class="pilcrow">¶</a></p>
+<p id="section-2.3-5">For any implementation, if a syntactically invalid JSON Path is provided, the implementation MUST return an error.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
 <p id="section-2.3-6">If a syntactially invalid JSON document is provided, any implementation SHOULD return an error.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.4">
-        <h3 id="name-syntax-3">
-<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-3" class="section-name selfRef">Syntax</a>
+        <h3 id="name-syntax-6">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-syntax-6" class="section-name selfRef">Syntax</a>
         </h3>
-<p id="section-2.4-1">Syntactically, a JSONPath consists of a root selector (<code>$</code>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-1">Syntactically, a JSON Path consists of a root selector (<code>$</code>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
 <div id="section-2.4-2">
 <pre class="sourcecode lang-abnf">
 json-path = root-selector *matcher
@@ -1328,20 +1349,20 @@ root-selector = %x24               ; $ selects document root node
 <p id="section-2.4-3">The syntax and semantics of each matcher is defined below.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.5">
-        <h3 id="name-semantics-3">
-<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-3" class="section-name selfRef">Semantics</a>
+        <h3 id="name-semantics-6">
+<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-semantics-6" class="section-name selfRef">Semantics</a>
         </h3>
 <p id="section-2.5-1">The root selector <code>$</code> not only selects the root node of the input document, but it also produces as output a list consisting of one node: the input document.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
 <p id="section-2.5-2">A matcher may match a node and, if it matches, may then select zero or more descendants of the node for further processing.
                But there's more to it than this: each matcher acts on a list of nodes and produces a list of nodes, as follows.<a href="#section-2.5-2" class="pilcrow">¶</a></p>
-<p id="section-2.5-3">After the root selector, the remainder of the JSONPath is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
-               matching the JSONPath to the input JSON document.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
+<p id="section-2.5-3">After the root selector, the remainder of the JSON Path is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
+               matching the JSON Path to the input JSON document.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
 <p id="section-2.5-4">Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher may or may not match the node. If the matcher
                matches the node, it selects zero or more descendants of the node.
                The output list of nodes of a matcher is the concatenation of the lists of selected descendents for each input node.<a href="#section-2.5-4" class="pilcrow">¶</a></p>
-<p id="section-2.5-5">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSONPath
+<p id="section-2.5-5">A specific, non-normative example will make this clearer. Suppose the input document is: <code>{"a":[{"b":0},{"b":1},{"b":2}]}</code>. As we will see later, the JSON Path
                <code>$.a[*].b</code> selects the following list of nodes: <code>0</code>, <code>1</code>, <code>2</code>. Let's walk through this in detail.<a href="#section-2.5-5" class="pilcrow">¶</a></p>
-<p id="section-2.5-6">The JSONPath consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
+<p id="section-2.5-6">The JSON Path consists of <code>$</code> followed by three matchers: <code>.a</code>, <code>[*]</code>, and <code>.b</code>.<a href="#section-2.5-6" class="pilcrow">¶</a></p>
 <p id="section-2.5-7">Firstly, <code>$</code> matches the input document and selects the root node which is the input document. So the result is a list consisting of just the root node.<a href="#section-2.5-7" class="pilcrow">¶</a></p>
 <p id="section-2.5-8">Next, <code>.a</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"a"</code>.
                The result is again a list of one node: <code>[{"b":0},{"b":1},{"b":2}]</code>.<a href="#section-2.5-8" class="pilcrow">¶</a></p>
@@ -1349,7 +1370,7 @@ root-selector = %x24               ; $ selects document root node
                The result is a list of three nodes: <code>{"b":0}</code>, <code>{"b":1}</code>, and <code>{"b":2}</code>.<a href="#section-2.5-9" class="pilcrow">¶</a></p>
 <p id="section-2.5-10">Finally, <code>.b</code> matches any input node of type object and selects any value of the input node corresponding to the key <code>"b"</code>.
                The result is the concatenation of three lists each of length one containing <code>0</code>, <code>1</code>, <code>2</code>, respectively.<a href="#section-2.5-10" class="pilcrow">¶</a></p>
-<p id="section-2.5-11">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
+<p id="section-2.5-11">As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSON Path matches no nodes.<a href="#section-2.5-11" class="pilcrow">¶</a></p>
 <p id="section-2.5-12">In what follows, the semantics of each matcher are defined for each type of node.<a href="#section-2.5-12" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6">
@@ -1361,8 +1382,8 @@ root-selector = %x24               ; $ selects document root node
 <a href="#section-2.6.1" class="section-number selfRef">2.6.1. </a><a href="#name-dot-child-matcher-2" class="section-name selfRef">Dot Child Matcher</a>
           </h4>
 <section id="section-2.6.1.1">
-            <h5 id="name-syntax-4">
-<a href="#name-syntax-4" class="section-name selfRef">Syntax</a>
+            <h5 id="name-syntax-7">
+<a href="#name-syntax-7" class="section-name selfRef">Syntax</a>
             </h5>
 <p id="section-2.6.1.1-1">A dot child matcher has a key known as a dot child name or a single asterisk (<code>*</code>).<a href="#section-2.6.1.1-1" class="pilcrow">¶</a></p>
 <p id="section-2.6.1.1-2">A dot child name corresponds to a key in a JSON object, without the surrounding double quotes (<code>"</code>).<a href="#section-2.6.1.1-2" class="pilcrow">¶</a></p>
@@ -1374,17 +1395,120 @@ dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
 dot-child-name = TBD
 </pre><a href="#section-2.6.1.1-3" class="pilcrow">¶</a>
 </div>
-<p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Bracket Child Name" in (reference TBD).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Union Child" (<a href="#unionchild" class="xref">Section 2.6.2.3</a>).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6.1.2">
-            <h5 id="name-semantics-4">
-<a href="#name-semantics-4" class="section-name selfRef">Semantics</a>
+            <h5 id="name-semantics-7">
+<a href="#name-semantics-7" class="section-name selfRef">Semantics</a>
             </h5>
 <p id="section-2.6.1.2-1">A dot child name which is not a single asterisk (<code>*</code>) matches any node which is an object having a key equal to the dot child name
                   and selects the value corresponding to that key.
                   It does not match a node which is not an object.<a href="#section-2.6.1.2-1" class="pilcrow">¶</a></p>
 <p id="section-2.6.1.2-2">A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
                      It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
+</section>
+</section>
+<section id="section-2.6.2">
+          <h4 id="name-union-matcher-2">
+<a href="#section-2.6.2" class="section-number selfRef">2.6.2. </a><a href="#name-union-matcher-2" class="section-name selfRef">Union Matcher</a>
+          </h4>
+<section id="section-2.6.2.1">
+            <h5 id="name-syntax-8">
+<a href="#section-2.6.2.1" class="section-number selfRef">2.6.2.1. </a><a href="#name-syntax-8" class="section-name selfRef">Syntax</a>
+            </h5>
+<p id="section-2.6.2.1-1">A union matcher consists of one or more union elements.<a href="#section-2.6.2.1-1" class="pilcrow">¶</a></p>
+<div id="section-2.6.2.1-2">
+<pre class="sourcecode lang-abnf">
+matcher =/ union
+union = %x5B ws union-elements ws %x5D ; [...]
+ws = *%x20                             ; zero or more spaces
+union-elements = union-element /
+                 union-element ws %x2C ws union-elements
+                                       ; ,-separated list
+</pre><a href="#section-2.6.2.1-2" class="pilcrow">¶</a>
+</div>
+</section>
+<section id="section-2.6.2.2">
+            <h5 id="name-semantics-8">
+<a href="#section-2.6.2.2" class="section-number selfRef">2.6.2.2. </a><a href="#name-semantics-8" class="section-name selfRef">Semantics</a>
+            </h5>
+<p id="section-2.6.2.2-1">A union matches any node which is matched by at least one of the union elements and selects the concatenation of the
+                     lists (in the order of the matchers) of descendants selected by the union elements.<a href="#section-2.6.2.2-1" class="pilcrow">¶</a></p>
+</section>
+<div id="unionchild">
+<section id="section-2.6.2.3">
+            <h5 id="name-union-child-2">
+<a href="#section-2.6.2.3" class="section-number selfRef">2.6.2.3. </a><a href="#name-union-child-2" class="section-name selfRef">Union Child</a>
+            </h5>
+<section id="section-2.6.2.3.1">
+              <h6 id="name-syntax-9">
+<a href="#name-syntax-9" class="section-name selfRef">Syntax</a>
+              </h6>
+<p id="section-2.6.2.3.1-1">A union child is a union element consisting of a quoted string.<a href="#section-2.6.2.3.1-1" class="pilcrow">¶</a></p>
+<div id="section-2.6.2.3.1-2">
+<pre class="sourcecode lang-abnf">
+union-element = union-child ; see below for more alternatives
+union-child = %x27 *single-quoted %x27 / ; 'string'
+              %x22 *double-quoted %x22   ; "string"
+
+single-quoted = %x5C %x27 / ; \' (escaped single quote)
+                %x5C %x5C / ; \\ (escaped reverse solidus)
+                %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
+                            ; any Unicode code point except ' or \
+
+double-quoted = %x5C 5x22 / ; \" (escaped double quote)
+                %x5C 5x5C / ; \\ (escaped reverse solidus)
+                %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
+                            ; any Unicode code point except " or \
+</pre><a href="#section-2.6.2.3.1-2" class="pilcrow">¶</a>
+</div>
+<p id="section-2.6.2.3.1-3">Note: the syntax does not allow any character other than a quote or reverse solidus to be escaped.<a href="#section-2.6.2.3.1-3" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6.2.3.2">
+              <h6 id="name-semantics-9">
+<a href="#name-semantics-9" class="section-name selfRef">Semantics</a>
+              </h6>
+<p id="section-2.6.2.3.2-1">If the union child is a quoted string, the string must first have the surrounding quotes removed and then be unescaped
+                        as describe below.
+                        The union child matches any node which is an object having a key equal to the unescaped value of the union child string
+                        and selects the value corresponding to that key.
+                        It does not match a node which is not an object.<a href="#section-2.6.2.3.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.3.2-2">After the surrounding quotes have been removed, a string is unescaped by replacing each escaped quote by the corresponding
+                        quote and replacing each escaped reverse solidus by a reverse solidus.<a href="#section-2.6.2.3.2-2" class="pilcrow">¶</a></p>
+</section>
+</section>
+</div>
+<section id="section-2.6.2.4">
+            <h5 id="name-array-index-2">
+<a href="#section-2.6.2.4" class="section-number selfRef">2.6.2.4. </a><a href="#name-array-index-2" class="section-name selfRef">Array Index</a>
+            </h5>
+<section id="section-2.6.2.4.1">
+              <h6 id="name-syntax-10">
+<a href="#name-syntax-10" class="section-name selfRef">Syntax</a>
+              </h6>
+<p id="section-2.6.2.4.1-1">An array index is a union element consisting of an integer (in base 10).<a href="#section-2.6.2.4.1-1" class="pilcrow">¶</a></p>
+<div id="section-2.6.2.4.1-2">
+<pre class="sourcecode lang-abnf">
+union-element =/ integer
+integer = [%x2D] (%x30 / (%x31-39 *%x30-39))
+                            ; optional - followed by 0 or
+                            ; sequence of digits with no leading zero
+</pre><a href="#section-2.6.2.4.1-2" class="pilcrow">¶</a>
+</div>
+<p id="section-2.6.2.4.1-3">Note: the syntax does not allow integers with leading zeros such as <code>01</code> and <code>-01</code>.<a href="#section-2.6.2.4.1-3" class="pilcrow">¶</a></p>
+</section>
+<section id="section-2.6.2.4.2">
+              <h6 id="name-semantics-10">
+<a href="#name-semantics-10" class="section-name selfRef">Semantics</a>
+              </h6>
+<p id="section-2.6.2.4.2-1">An array index matches any node which is an array and selects any element of the array indexed by the integer index.
+                        It does not match a node which is not an array.<a href="#section-2.6.2.4.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.4.2-2">A non-negative index <code>i</code> selects an element of an array of length <code>len</code> if and only if <code>0 &lt;= i &lt; len</code>.
+                        The index <code>0</code> selects the first element of a non-empty array and, providing <code>i &lt; len - 1</code>, index <code>i + 1</code>
+                        selects the element immedately after (in array order) the element selected by index <code>i</code>.<a href="#section-2.6.2.4.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.6.2.4.2-3">A negative index <code>j</code> selects an element of an array of length <code>len</code> if and only if <code>0 &lt;= j + len &lt; len</code>,
+                        in which case it selects the same element as selected by the non-negative index <code>j + len</code>.<a href="#section-2.6.2.4.2-3" class="pilcrow">¶</a></p>
+</section>
 </section>
 </section>
 </section>
@@ -1430,6 +1554,10 @@ dot-child-name = TBD
 <dt id="RFC2119">[RFC2119]</dt>
 <dd>
 <span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC3629">[RFC3629]</dt>
+<dd>
+<span class="refAuthor">Yergeau, F.</span>, <span class="refTitle">"UTF-8, a transformation format of ISO 10646"</span>, <span class="seriesInfo">STD 63</span>, <span class="seriesInfo">RFC 3629</span>, <span class="seriesInfo">DOI 10.17487/RFC3629</span>, <time datetime="2003-11">November 2003</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3629">https://www.rfc-editor.org/info/rfc3629</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC5234">[RFC5234]</dt>
 <dd>

--- a/draft-normington-jsonpath-latest.txt
+++ b/draft-normington-jsonpath-latest.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                       G. Normington, Ed.
 Internet-Draft                                              VMware, Inc.
-Intended status: Standards Track                            17 July 2020
-Expires: 18 January 2021
+Intended status: Standards Track                            28 July 2020
+Expires: 29 January 2021
 
 
                  JavaScript Object Notation (JSON) Path
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 18 January 2021.
+   This Internet-Draft will expire on 29 January 2021.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Normington               Expires 18 January 2021                [Page 1]
+Normington               Expires 29 January 2021                [Page 1]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -84,14 +84,14 @@ Table of Contents
          2.6.2.1.  Syntax  . . . . . . . . . . . . . . . . . . . . .   6
          2.6.2.2.  Semantics . . . . . . . . . . . . . . . . . . . .   6
          2.6.2.3.  Union Child . . . . . . . . . . . . . . . . . . .   6
-         2.6.2.4.  Array Index . . . . . . . . . . . . . . . . . . .   7
-   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
-   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
-   5.  Alternatives  . . . . . . . . . . . . . . . . . . . . . . . .   8
-   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
-     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
-     6.2.  Informative References  . . . . . . . . . . . . . . . . .   9
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   9
+         2.6.2.4.  Array Index . . . . . . . . . . . . . . . . . . .   8
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+   5.  Alternatives  . . . . . . . . . . . . . . . . . . . . . . . .   9
+   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   9
+     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   9
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .  10
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  10
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Normington               Expires 18 January 2021                [Page 2]
+Normington               Expires 29 January 2021                [Page 2]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -165,7 +165,7 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
 
 
-Normington               Expires 18 January 2021                [Page 3]
+Normington               Expires 29 January 2021                [Page 3]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -221,7 +221,7 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
 
 
-Normington               Expires 18 January 2021                [Page 4]
+Normington               Expires 29 January 2021                [Page 4]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -277,7 +277,7 @@ Syntax
 
 
 
-Normington               Expires 18 January 2021                [Page 5]
+Normington               Expires 29 January 2021                [Page 5]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -333,40 +333,96 @@ Syntax
 
 
 
-Normington               Expires 18 January 2021                [Page 6]
+Normington               Expires 29 January 2021                [Page 6]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
 
    union-element = union-child ; see below for more alternatives
-   union-child = %x27 *single-quoted %x27 / ; 'string'
-                 %x22 *double-quoted %x22   ; "string"
+   union-child = %x22 *double-quoted %x22 / ; "string"
+                 %x27 *single-quoted %x27   ; 'string'
 
-   single-quoted = %x5C %x27 / ; \' (escaped single quote)
-                   %x5C %x5C / ; \\ (escaped reverse solidus)
-                   %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
-                               ; any Unicode code point except ' or \
+   double-quoted = dq-unescaped /
+             escape (
+                 %x22 /          ; "    quotation mark  U+0022
+                 %x2F /          ; /    solidus         U+002F
+                 %x5C /          ; \    reverse solidus U+005C
+                 %x62 /          ; b    backspace       U+0008
+                 %x66 /          ; f    form feed       U+000C
+                 %x6E /          ; n    line feed       U+000A
+                 %x72 /          ; r    carriage return U+000D
+                 %x74 /          ; t    tab             U+0009
+                 %x75 4HEXDIG )  ; uXXXX                U+XXXX
 
-   double-quoted = %x5C 5x22 / ; \" (escaped double quote)
-                   %x5C 5x5C / ; \\ (escaped reverse solidus)
-                   %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
-                               ; any Unicode code point except " or \
 
-   Note: the syntax does not allow any character other than a quote or
-   reverse solidus to be escaped.
+         dq-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+
+   single-quoted = sq-unescaped /
+             escape (
+                 %x27 /          ; '    apostrophe      U+0027
+                 %x2F /          ; /    solidus         U+002F
+                 %x5C /          ; \    reverse solidus U+005C
+                 %x62 /          ; b    backspace       U+0008
+                 %x66 /          ; f    form feed       U+000C
+                 %x6E /          ; n    line feed       U+000A
+                 %x72 /          ; r    carriage return U+000D
+                 %x74 /          ; t    tab             U+0009
+                 %x75 4HEXDIG )  ; uXXXX                U+XXXX
+
+         sq-unescaped = %x20-26 / %x28-5B / %x5D-10FFFF
+
+   escape = %x5C                 ; \
+
+   HEXDIG =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+   DIGIT =  %x30-39              ; 0-9
+
+   Note: double-quoted strings follow JSON in RFC 8259 [RFC8259].
+   Single-quoted strings follow an analogous pattern.
 
 Semantics
 
-   If the union child is a quoted string, the string must first have the
-   surrounding quotes removed and then be unescaped as describe below.
-   The union child matches any node which is an object having a key
-   equal to the unescaped value of the union child string and selects
-   the value corresponding to that key.  It does not match a node which
-   is not an object.
+   If the union child is a quoted string, the string MUST be converted
+   to a key by removing the surrounding quotes and replacing each escape
+   sequence with its equivalent Unicode character, as in the table
+   below:
 
-   After the surrounding quotes have been removed, a string is unescaped
-   by replacing each escaped quote by the corresponding quote and
-   replacing each escaped reverse solidus by a reverse solidus.
+
+
+
+Normington               Expires 29 January 2021                [Page 7]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
+
+                  +-----------------+-------------------+
+                  | Escape Sequence | Unicode Character |
+                  +=================+===================+
+                  |    %x5C %x22    |       U+0022      |
+                  +-----------------+-------------------+
+                  |    %x5C %x27    |       U+0027      |
+                  +-----------------+-------------------+
+                  |    %x5C %x2F    |       U+002F      |
+                  +-----------------+-------------------+
+                  |    %x5C %x5C    |       U+005C      |
+                  +-----------------+-------------------+
+                  |    %x5C %x62    |       U+0008      |
+                  +-----------------+-------------------+
+                  |    %x5C %x66    |       U+000C      |
+                  +-----------------+-------------------+
+                  |    %x5C %x6E    |       U+000A      |
+                  +-----------------+-------------------+
+                  |    %x5C %x72    |       U+000D      |
+                  +-----------------+-------------------+
+                  |    %x5C %x74    |       U+0009      |
+                  +-----------------+-------------------+
+                  |    %x5C uXXXX   |       U+XXXX      |
+                  +-----------------+-------------------+
+
+                   Table 1: Escape Sequence Replacements
+
+   The union child matches any node which is an object with this key and
+   selects the value corresponding to the key.  It does not match a node
+   which is not an object.
 
 2.6.2.4.  Array Index
 
@@ -389,7 +445,7 @@ Syntax
 
 
 
-Normington               Expires 18 January 2021                [Page 7]
+Normington               Expires 29 January 2021                [Page 8]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -445,7 +501,7 @@ Semantics
 
 
 
-Normington               Expires 18 January 2021                [Page 8]
+Normington               Expires 29 January 2021                [Page 9]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -501,4 +557,4 @@ Author's Address
 
 
 
-Normington               Expires 18 January 2021                [Page 9]
+Normington               Expires 29 January 2021               [Page 10]

--- a/draft-normington-jsonpath-latest.txt
+++ b/draft-normington-jsonpath-latest.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                       G. Normington, Ed.
 Internet-Draft                                              VMware, Inc.
-Intended status: Standards Track                            14 July 2020
-Expires: 15 January 2021
+Intended status: Standards Track                            17 July 2020
+Expires: 18 January 2021
 
 
                  JavaScript Object Notation (JSON) Path
@@ -13,7 +13,7 @@ Expires: 15 January 2021
 
 Abstract
 
-   JSONPath defines a string syntax for identifying values within a
+   JSON Path defines a string syntax for identifying values within a
    JavaScript Object Notation (JSON) document.
 
 Note
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 15 January 2021.
+   This Internet-Draft will expire on 18 January 2021.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Normington               Expires 15 January 2021                [Page 1]
+Normington               Expires 18 January 2021                [Page 1]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
@@ -71,8 +71,8 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   2
-     1.2.  ABNF Syntax . . . . . . . . . . . . . . . . . . . . . . .   2
-   2.  JSONPath Syntax and Semantics . . . . . . . . . . . . . . . .   3
+     1.2.  ABNF Syntax . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  JSON Path Syntax and Semantics  . . . . . . . . . . . . . . .   3
      2.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   3
      2.3.  Implementation  . . . . . . . . . . . . . . . . . . . . .   3
@@ -80,18 +80,23 @@ Table of Contents
      2.5.  Semantics . . . . . . . . . . . . . . . . . . . . . . . .   4
      2.6.  Matchers  . . . . . . . . . . . . . . . . . . . . . . . .   5
        2.6.1.  Dot Child Matcher . . . . . . . . . . . . . . . . . .   5
-   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
-   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
-   5.  Alternatives  . . . . . . . . . . . . . . . . . . . . . . . .   6
-   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
-     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   6
-     6.2.  Informative References  . . . . . . . . . . . . . . . . .   6
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   7
+       2.6.2.  Union Matcher . . . . . . . . . . . . . . . . . . . .   6
+         2.6.2.1.  Syntax  . . . . . . . . . . . . . . . . . . . . .   6
+         2.6.2.2.  Semantics . . . . . . . . . . . . . . . . . . . .   6
+         2.6.2.3.  Union Child . . . . . . . . . . . . . . . . . . .   6
+         2.6.2.4.  Array Index . . . . . . . . . . . . . . . . . . .   7
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
+   5.  Alternatives  . . . . . . . . . . . . . . . . . . . . . . . .   8
+   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
+     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .   9
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   9
 
 1.  Introduction
 
-   JSONPath was introduced by Stefan Goessner as a simple form of XPath
-   for JSON.  See his original article [Goessner].
+   JSON Path, or rather JSONPath, was introduced by Stefan Goessner as a
+   simple form of XPath for JSON.  See his original article [Goessner].
 
    JSON is defined by RFC 8259 [RFC8259].
 
@@ -101,26 +106,35 @@ Table of Contents
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in RFC 2119 [RFC2119].
 
+
+
+
+Normington               Expires 18 January 2021                [Page 2]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
+
 1.2.  ABNF Syntax
 
    The syntax in this document conforms to ABNF as defined by RFC 5234
    [RFC5234].
 
+   ABNF terminal values in this document define Unicode code points
+   rather than their UTF-8 encoding.  For example, the Unicode PLACE OF
+   INTEREST SIGN (U+2318) would be defined in ABNF as "%x2318".
 
-
-
-Normington               Expires 15 January 2021                [Page 2]
-
-Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
-
-
-2.  JSONPath Syntax and Semantics
+2.  JSON Path Syntax and Semantics
 
 2.1.  Overview
 
-   A JSONPath is a string which matches zero or more nodes of any JSON
-   document.  A valid JSONPath conforms to the ABNF syntax defined by
+   A JSON Path is a string which matches zero or more nodes of any JSON
+   document.  A valid JSON Path conforms to the ABNF syntax defined by
    this document.
+
+   A JSON Path MUST be encoded using UTF-8.  To parse a JSON Path
+   according to the grammar in this document, its UTF-8 form SHOULD
+   first be decoded into Unicode code points as described in RFC 3629
+   [RFC3629].
 
 2.2.  Terminology
 
@@ -138,41 +152,44 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 2.3.  Implementation
 
    An implementation of this specification, from now on referred to
-   simply as "an implementation", SHOULD takes two inputs, a JSONPath
+   simply as "an implementation", SHOULD takes two inputs, a JSON Path
    and a JSON document, and produce a possibly empty list of nodes of
-   the JSON document which match the JSONPath or an error (but not
+   the JSON document which match the JSON Path or an error (but not
    both).
 
    If there is no matching node and no error has occurred, an
    implementation MUST return an empty list of nodes.
 
-   Syntax errors in the JSONPath SHOULD be detected before matching is
+
+
+
+
+
+Normington               Expires 18 January 2021                [Page 3]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
+
+   Syntax errors in the JSON Path SHOULD be detected before matching is
    attempted since they do not depend on the JSON document.  Therefore,
-   an implementation SHOULD take a JSONPath and produce an optional
+   an implementation SHOULD take a JSON Path and produce an optional
    syntax error and then, if and only if an error was not produced,
    SHOULD take a JSON document and produce a list of matches or an error
    (but not both).
 
-   Alternatively, an implementation MAY take a JSONPath and a JSON
+   Alternatively, an implementation MAY take a JSON Path and a JSON
    document and produce a list of matches or an optional error (but not
    both).
 
-   For any implementation, if a syntactically invalid JSONPath is
+   For any implementation, if a syntactically invalid JSON Path is
    provided, the implementation MUST return an error.
 
    If a syntactially invalid JSON document is provided, any
    implementation SHOULD return an error.
 
-
-
-Normington               Expires 15 January 2021                [Page 3]
-
-Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
-
-
 2.4.  Syntax
 
-   Syntactically, a JSONPath consists of a root selector ("$"), which
+   Syntactically, a JSON Path consists of a root selector ("$"), which
    selects the root node of a JSON document, followed by a possibly
    empty sequence of _matchers_.
 
@@ -192,10 +209,22 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
    more to it than this: each matcher acts on a list of nodes and
    produces a list of nodes, as follows.
 
-   After the root selector, the remainder of the JSONPath is processed
+   After the root selector, the remainder of the JSON Path is processed
    by passing lists of nodes from one matcher to the next ending up with
-   a list of nodes which is the result of matching the JSONPath to the
+   a list of nodes which is the result of matching the JSON Path to the
    input JSON document.
+
+
+
+
+
+
+
+
+Normington               Expires 18 January 2021                [Page 4]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
 
    Each matcher acts on its input list of nodes as follows.  For each
    node in the list, the matcher may or may not match the node.  If the
@@ -205,11 +234,11 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
    A specific, non-normative example will make this clearer.  Suppose
    the input document is: "{"a":[{"b":0},{"b":1},{"b":2}]}".  As we will
-   see later, the JSONPath "$.a[*].b" selects the following list of
+   see later, the JSON Path "$.a[*].b" selects the following list of
    nodes: "0", "1", "2".  Let's walk through this in detail.
 
-   The JSONPath consists of "$" followed by three matchers: ".a", "[*]",
-   and ".b".
+   The JSON Path consists of "$" followed by three matchers: ".a",
+   "[*]", and ".b".
 
    Firstly, "$" matches the input document and selects the root node
    which is the input document.  So the result is a list consisting of
@@ -218,13 +247,6 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
    Next, ".a" matches any input node of type object and selects any
    value of the input node corresponding to the key ""a"".  The result
    is again a list of one node: "[{"b":0},{"b":1},{"b":2}]".
-
-
-
-Normington               Expires 15 January 2021                [Page 4]
-
-Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
-
 
    Next, "[*]" matches any input node which is an array and selects all
    the elements of the input node.  The result is a list of three nodes:
@@ -236,7 +258,7 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
    "0", "1", "2", respectively.
 
    As a consequence of this approach, if any of the matchers matches no
-   nodes, then the whole JSONPath matches no nodes.
+   nodes, then the whole JSON Path matches no nodes.
 
    In what follows, the semantics of each matcher are defined for each
    type of node.
@@ -253,13 +275,20 @@ Syntax
    A dot child name corresponds to a key in a JSON object, without the
    surrounding double quotes (""").
 
+
+
+Normington               Expires 18 January 2021                [Page 5]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
+
    matcher = dot-child             ; see below for alternatives
    dot-child = %x2E dot-child-name / ; .<dot-child-name>
                %x2E %x2A             ; .*
    dot-child-name = TBD
 
    More general child names, such as the empty string, are supported by
-   "Bracket Child Name" in (reference TBD).
+   "Union Child" (Section 2.6.2.3).
 
 Semantics
 
@@ -274,13 +303,112 @@ Semantics
    the elements of the array.  It does not match a number, string, or
    literal node.
 
+2.6.2.  Union Matcher
+
+2.6.2.1.  Syntax
+
+   A union matcher consists of one or more union elements.
+
+   matcher =/ union
+   union = %x5B ws union-elements ws %x5D ; [...]
+   ws = *%x20                             ; zero or more spaces
+   union-elements = union-element /
+                    union-element ws %x2C ws union-elements
+                                          ; ,-separated list
+
+2.6.2.2.  Semantics
+
+   A union matches any node which is matched by at least one of the
+   union elements and selects the concatenation of the lists (in the
+   order of the matchers) of descendants selected by the union elements.
+
+2.6.2.3.  Union Child
+
+Syntax
+
+   A union child is a union element consisting of a quoted string.
 
 
 
-Normington               Expires 15 January 2021                [Page 5]
+
+
+
+Normington               Expires 18 January 2021                [Page 6]
 
 Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
 
+
+   union-element = union-child ; see below for more alternatives
+   union-child = %x27 *single-quoted %x27 / ; 'string'
+                 %x22 *double-quoted %x22   ; "string"
+
+   single-quoted = %x5C %x27 / ; \' (escaped single quote)
+                   %x5C %x5C / ; \\ (escaped reverse solidus)
+                   %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
+                               ; any Unicode code point except ' or \
+
+   double-quoted = %x5C 5x22 / ; \" (escaped double quote)
+                   %x5C 5x5C / ; \\ (escaped reverse solidus)
+                   %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
+                               ; any Unicode code point except " or \
+
+   Note: the syntax does not allow any character other than a quote or
+   reverse solidus to be escaped.
+
+Semantics
+
+   If the union child is a quoted string, the string must first have the
+   surrounding quotes removed and then be unescaped as describe below.
+   The union child matches any node which is an object having a key
+   equal to the unescaped value of the union child string and selects
+   the value corresponding to that key.  It does not match a node which
+   is not an object.
+
+   After the surrounding quotes have been removed, a string is unescaped
+   by replacing each escaped quote by the corresponding quote and
+   replacing each escaped reverse solidus by a reverse solidus.
+
+2.6.2.4.  Array Index
+
+Syntax
+
+   An array index is a union element consisting of an integer (in base
+   10).
+
+   union-element =/ integer
+   integer = [%x2D] (%x30 / (%x31-39 *%x30-39))
+                               ; optional - followed by 0 or
+                               ; sequence of digits with no leading zero
+
+   Note: the syntax does not allow integers with leading zeros such as
+   "01" and "-01".
+
+
+
+
+
+
+
+Normington               Expires 18 January 2021                [Page 7]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
+
+Semantics
+
+   An array index matches any node which is an array and selects any
+   element of the array indexed by the integer index.  It does not match
+   a node which is not an array.
+
+   A non-negative index "i" selects an element of an array of length
+   "len" if and only if "0 <= i < len".  The index "0" selects the first
+   element of a non-empty array and, providing "i < len - 1", index "i +
+   1" selects the element immedately after (in array order) the element
+   selected by index "i".
+
+   A negative index "j" selects an element of an array of length "len"
+   if and only if "0 <= j + len < len", in which case it selects the
+   same element as selected by the non-negative index "j + len".
 
 3.  IANA Considerations
 
@@ -312,6 +440,20 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
 
+
+
+
+
+
+Normington               Expires 18 January 2021                [Page 8]
+
+Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
+
+
+   [RFC3629]  Yergeau, F., "UTF-8, a transformation format of ISO
+              10646", STD 63, RFC 3629, DOI 10.17487/RFC3629, November
+              2003, <https://www.rfc-editor.org/info/rfc3629>.
+
    [RFC5234]  Crocker, D., Ed. and P. Overell, "Augmented BNF for Syntax
               Specifications: ABNF", STD 68, RFC 5234,
               DOI 10.17487/RFC5234, January 2008,
@@ -326,17 +468,6 @@ Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
               Text on Security Considerations", BCP 72, RFC 3552,
               DOI 10.17487/RFC3552, July 2003,
               <https://www.rfc-editor.org/info/rfc3552>.
-
-
-
-
-
-
-
-Normington               Expires 15 January 2021                [Page 6]
-
-Internet-Draft   JavaScript Object Notation (JSON) Path        July 2020
-
 
    [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
               IANA Considerations Section in RFCs", RFC 5226,
@@ -370,23 +501,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Normington               Expires 15 January 2021                [Page 7]
+Normington               Expires 18 January 2021                [Page 9]

--- a/draft-normington-jsonpath-latest.xml
+++ b/draft-normington-jsonpath-latest.xml
@@ -12,7 +12,7 @@
       submissionType="IETF"
       xml:lang="en"
       tocInclude="true"
-      tocDepth="3"
+      tocDepth="4"
       symRefs="true"
       sortRefs="true"
       version="3">
@@ -74,7 +74,7 @@
         keywords will be used for the search engine. -->
 
    <abstract>
-      <t>JSONPath defines a string syntax for identifying values
+      <t>JSON Path defines a string syntax for identifying values
    within a JavaScript Object Notation (JSON) document.</t>
     </abstract>
     <note>
@@ -88,7 +88,7 @@
     <section numbered="true" toc="default">
       <name>Introduction</name>
       <!-- move the following to an Acknowledgements appendix and write a proper introduction -->
-      <t>JSONPath was introduced by Stefan Goessner as a simple form of XPath for JSON.
+      <t>JSON Path, or rather JSONPath, was introduced by Stefan Goessner as a simple form of XPath for JSON.
          See his original article <xref target="Goessner" format="default">Goessner</xref>.
       </t>
       <t>JSON is defined by <xref target="RFC8259" format="default">RFC&nbsp;8259</xref>.
@@ -103,14 +103,21 @@
 
       <section numbered="true" toc="default">
         <name>ABNF Syntax</name>
-        <t>The syntax in this document conforms to ABNF as defined by <xref target="RFC5234" format="default">RFC&nbsp;5234</xref>.</t>
+        <t>The syntax in this document conforms to ABNF as defined by <xref target="RFC5234" format="default">RFC&nbsp;5234</xref>.
+        </t>
+        <t>ABNF terminal values in this document define Unicode code points rather than their UTF-8 encoding.
+           For example, the Unicode PLACE OF INTEREST SIGN (U+2318) would be defined in ABNF as <tt>%x2318</tt>.
+        </t>
       </section>
     </section>
    <section numbered="true" toc="default">
-      <name>JSONPath Syntax and Semantics</name>
+      <name>JSON Path Syntax and Semantics</name>
          <section numbered="true" toc="default">
             <name>Overview</name>
-            <t>A JSONPath is a string which matches zero or more nodes of any JSON document. A valid JSONPath conforms to the ABNF syntax defined by this document.
+            <t>A JSON Path is a string which matches zero or more nodes of any JSON document. A valid JSON Path conforms to the ABNF syntax defined by this document.
+            </t>
+            <t>A JSON Path MUST be encoded using UTF-8. To parse a JSON Path according to the grammar in this document, its UTF-8 form SHOULD first be decoded into Unicode code points as described
+               in <xref target="RFC3629" format="default">RFC&nbsp;3629</xref>.
             </t>
          </section>
          <section numbered="true" toc="default">
@@ -125,25 +132,25 @@
          </section>
          <section numbered="true" toc="default">
             <name>Implementation</name>
-            <t>An implementation of this specification, from now on referred to simply as "an implementation", SHOULD takes two inputs, a JSONPath and a JSON document, and produce
-               a possibly empty list of nodes of the JSON document which match the JSONPath or an error (but not both).
+            <t>An implementation of this specification, from now on referred to simply as "an implementation", SHOULD takes two inputs, a JSON Path and a JSON document, and produce
+               a possibly empty list of nodes of the JSON document which match the JSON Path or an error (but not both).
             </t>
             <t>If there is no matching node and no error has occurred, an implementation MUST return an empty list of nodes.
             </t>
-            <t>Syntax errors in the JSONPath SHOULD be detected before matching is attempted since they do not depend on the JSON document.
-               Therefore, an implementation SHOULD take a JSONPath and produce an optional syntax error and then,
+            <t>Syntax errors in the JSON Path SHOULD be detected before matching is attempted since they do not depend on the JSON document.
+               Therefore, an implementation SHOULD take a JSON Path and produce an optional syntax error and then,
                if and only if an error was not produced, SHOULD take a JSON document and produce a list of matches or an error (but not both).
             </t>
-            <t>Alternatively, an implementation MAY take a JSONPath and a JSON document and produce a list of matches or an optional error (but not both).
+            <t>Alternatively, an implementation MAY take a JSON Path and a JSON document and produce a list of matches or an optional error (but not both).
             </t>
-            <t>For any implementation, if a syntactically invalid JSONPath is provided, the implementation MUST return an error.
+            <t>For any implementation, if a syntactically invalid JSON Path is provided, the implementation MUST return an error.
             </t>
             <t>If a syntactially invalid JSON document is provided, any implementation SHOULD return an error.
             </t>
          </section>
          <section numbered="true" toc="default">
             <name>Syntax</name>
-            <t>Syntactically, a JSONPath consists of a root selector (<tt>$</tt>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.
+            <t>Syntactically, a JSON Path consists of a root selector (<tt>$</tt>), which selects the root node of a JSON document, followed by a possibly empty sequence of <em>matchers</em>.
             </t>
             <sourcecode type="abnf">
 json-path = root-selector *matcher
@@ -159,17 +166,17 @@ root-selector = %x24               ; $ selects document root node
             <t>A matcher may match a node and, if it matches, may then select zero or more descendants of the node for further processing.
                But there's more to it than this: each matcher acts on a list of nodes and produces a list of nodes, as follows.
             </t>
-            <t>After the root selector, the remainder of the JSONPath is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
-               matching the JSONPath to the input JSON document.
+            <t>After the root selector, the remainder of the JSON Path is processed by passing lists of nodes from one matcher to the next ending up with a list of nodes which is the result of
+               matching the JSON Path to the input JSON document.
             </t>
             <t>Each matcher acts on its input list of nodes as follows. For each node in the list, the matcher may or may not match the node. If the matcher
                matches the node, it selects zero or more descendants of the node.
                The output list of nodes of a matcher is the concatenation of the lists of selected descendents for each input node. 
             </t>
-            <t>A specific, non-normative example will make this clearer. Suppose the input document is: <tt>{"a":[{"b":0},{"b":1},{"b":2}]}</tt>. As we will see later, the JSONPath
+            <t>A specific, non-normative example will make this clearer. Suppose the input document is: <tt>{"a":[{"b":0},{"b":1},{"b":2}]}</tt>. As we will see later, the JSON Path
                <tt>$.a[*].b</tt> selects the following list of nodes: <tt>0</tt>, <tt>1</tt>, <tt>2</tt>. Let's walk through this in detail.
             </t>
-            <t>The JSONPath consists of <tt>$</tt> followed by three matchers: <tt>.a</tt>, <tt>[*]</tt>, and <tt>.b</tt>.
+            <t>The JSON Path consists of <tt>$</tt> followed by three matchers: <tt>.a</tt>, <tt>[*]</tt>, and <tt>.b</tt>.
             </t>
             <t>Firstly, <tt>$</tt> matches the input document and selects the root node which is the input document. So the result is a list consisting of just the root node.
             </t>
@@ -182,7 +189,7 @@ root-selector = %x24               ; $ selects document root node
             <t>Finally, <tt>.b</tt> matches any input node of type object and selects any value of the input node corresponding to the key <tt>"b"</tt>.
                The result is the concatenation of three lists each of length one containing <tt>0</tt>, <tt>1</tt>, <tt>2</tt>, respectively.
             </t>
-            <t>As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSONPath matches no nodes.
+            <t>As a consequence of this approach, if any of the matchers matches no nodes, then the whole JSON Path matches no nodes.
             </t>
             <t>In what follows, the semantics of each matcher are defined for each type of node.
             </t>
@@ -191,7 +198,7 @@ root-selector = %x24               ; $ selects document root node
             <name>Matchers</name>
             <section numbered="true" toc="default">
                <name>Dot Child Matcher</name>
-               <section numbered="false" toc="default">
+               <section numbered="false" toc="exclude">
                   <name>Syntax</name>
                   <t>A dot child matcher has a key known as a dot child name or a single asterisk (<tt>*</tt>).
                   </t>
@@ -204,10 +211,10 @@ dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
 dot-child-name = TBD
                   </sourcecode>
                   <!-- TODO: define dot-child-name using an identifier like syntax. See https://github.com/cburgmer/json-path-comparison/issues/42 -->
-                  <t>More general child names, such as the empty string, are supported by "Bracket Child Name" in (reference TBD)<!-- <xref target="bracketchildname" format="default"/> -->.
+                  <t>More general child names, such as the empty string, are supported by "Union Child" (<xref target="unionchild" format="default"/>).
                   </t>
                </section>       
-               <section numbered="false" toc="default">
+               <section numbered="false" toc="exclude">
                   <name>Semantics</name>
                   <t>A dot child name which is not a single asterisk (<tt>*</tt>) matches any node which is an object having a key equal to the dot child name
                   and selects the value corresponding to that key.
@@ -217,6 +224,94 @@ dot-child-name = TBD
                      It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.
                   </t>
                </section>       
+            </section>       
+            <section numbered="true" toc="default">
+               <name>Union Matcher</name>
+               <section numbered="true" toc="default">
+                  <name>Syntax</name>
+                  <t>A union matcher consists of one or more union elements.
+                  </t>
+                  <sourcecode type="abnf">
+matcher =/ union
+union = %x5B ws union-elements ws %x5D ; [...]
+ws = *%x20                             ; zero or more spaces
+union-elements = union-element /
+                 union-element ws %x2C ws union-elements
+                                       ; ,-separated list
+                  </sourcecode>
+               </section>       
+               <section numbered="true" toc="default">
+                  <name>Semantics</name>
+                  <t>A union matches any node which is matched by at least one of the union elements and selects the concatenation of the
+                     lists (in the order of the matchers) of descendants selected by the union elements.
+                  </t>
+               </section>
+               <section numbered="true" toc="default" anchor="unionchild">
+                  <name>Union Child</name>
+                  <section numbered="false" toc="exclude">
+                     <name>Syntax</name>
+                     <t>A union child is a union element consisting of a quoted string.
+                     </t>
+                     <sourcecode type="abnf">
+union-element = union-child ; see below for more alternatives
+union-child = %x27 *single-quoted %x27 / ; 'string'
+              %x22 *double-quoted %x22   ; "string"
+
+single-quoted = %x5C %x27 / ; \' (escaped single quote)
+                %x5C %x5C / ; \\ (escaped reverse solidus)
+                %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
+                            ; any Unicode code point except ' or \
+
+double-quoted = %x5C 5x22 / ; \" (escaped double quote)
+                %x5C 5x5C / ; \\ (escaped reverse solidus)
+                %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
+                            ; any Unicode code point except " or \
+                     </sourcecode>
+                     <t>Note: the syntax does not allow any character other than a quote or reverse solidus to be escaped.
+                     </t>
+                  </section>       
+                  <section numbered="false" toc="exclude">
+                     <name>Semantics</name>
+                     <t>If the union child is a quoted string, the string must first have the surrounding quotes removed and then be unescaped
+                        as describe below.
+                        The union child matches any node which is an object having a key equal to the unescaped value of the union child string
+                        and selects the value corresponding to that key.
+                        It does not match a node which is not an object.
+                     </t>
+                     <t>After the surrounding quotes have been removed, a string is unescaped by replacing each escaped quote by the corresponding
+                        quote and replacing each escaped reverse solidus by a reverse solidus.
+                     </t>
+                  </section>       
+               </section>             
+               <section numbered="true" toc="default">
+                  <name>Array Index</name>
+                  <section numbered="false" toc="exclude">
+                     <name>Syntax</name>
+                     <t>An array index is a union element consisting of an integer (in base 10).
+                     </t>
+                     <sourcecode type="abnf">
+union-element =/ integer
+integer = [%x2D] (%x30 / (%x31-39 *%x30-39))
+                            ; optional - followed by 0 or
+                            ; sequence of digits with no leading zero
+                     </sourcecode>
+                     <t>Note: the syntax does not allow integers with leading zeros such as <tt>01</tt> and <tt>-01</tt>.
+                     </t>
+                  </section>       
+                  <section numbered="false" toc="exclude">
+                     <name>Semantics</name>
+                     <t>An array index matches any node which is an array and selects any element of the array indexed by the integer index.
+                        It does not match a node which is not an array.
+                     </t>
+                     <t>A non-negative index <tt>i</tt> selects an element of an array of length <tt>len</tt> if and only if <tt>0 &lt;= i &lt; len</tt>.
+                        The index <tt>0</tt> selects the first element of a non-empty array and, providing <tt>i &lt; len - 1</tt>, index <tt>i + 1</tt>
+                        selects the element immedately after (in array order) the element selected by index <tt>i</tt>.
+                     </t>
+                     <t>A negative index <tt>j</tt> selects an element of an array of length <tt>len</tt> if and only if <tt>0 &lt;= j + len &lt; len</tt>,
+                        in which case it selects the same element as selected by the non-negative index <tt>j + len</tt>.
+                     </t>
+                  </section>       
+               </section>             
             </section>       
          </section>       
    </section>
@@ -247,6 +342,7 @@ dot-child-name = TBD
       <references>
         <name>Normative References</name>
         <?rfc include="reference.RFC.2119.xml"?>
+        <?rfc include="reference.RFC.3629.xml"?>
         <?rfc include="reference.RFC.5234.xml"?>
       </references>
       <references>

--- a/draft-normington-jsonpath-latest.xml
+++ b/draft-normington-jsonpath-latest.xml
@@ -254,32 +254,74 @@ union-elements = union-element /
                      </t>
                      <sourcecode type="abnf">
 union-element = union-child ; see below for more alternatives
-union-child = %x27 *single-quoted %x27 / ; 'string'
-              %x22 *double-quoted %x22   ; "string"
+union-child = %x22 *double-quoted %x22 / ; "string"
+              %x27 *single-quoted %x27   ; 'string'
 
-single-quoted = %x5C %x27 / ; \' (escaped single quote)
-                %x5C %x5C / ; \\ (escaped reverse solidus)
-                %x00-26 / %x28-5B %x5D-D7FF / %xE000-10FFFF
-                            ; any Unicode code point except ' or \
+double-quoted = dq-unescaped /
+          escape (
+              %x22 /          ; "    quotation mark  U+0022
+              %x2F /          ; /    solidus         U+002F
+              %x5C /          ; \    reverse solidus U+005C
+              %x62 /          ; b    backspace       U+0008
+              %x66 /          ; f    form feed       U+000C
+              %x6E /          ; n    line feed       U+000A
+              %x72 /          ; r    carriage return U+000D
+              %x74 /          ; t    tab             U+0009
+              %x75 4HEXDIG )  ; uXXXX                U+XXXX
 
-double-quoted = %x5C 5x22 / ; \" (escaped double quote)
-                %x5C 5x5C / ; \\ (escaped reverse solidus)
-                %x00-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
-                            ; any Unicode code point except " or \
+
+      dq-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+
+single-quoted = sq-unescaped /
+          escape (
+              %x27 /          ; '    apostrophe      U+0027
+              %x2F /          ; /    solidus         U+002F
+              %x5C /          ; \    reverse solidus U+005C
+              %x62 /          ; b    backspace       U+0008
+              %x66 /          ; f    form feed       U+000C
+              %x6E /          ; n    line feed       U+000A
+              %x72 /          ; r    carriage return U+000D
+              %x74 /          ; t    tab             U+0009
+              %x75 4HEXDIG )  ; uXXXX                U+XXXX
+
+      sq-unescaped = %x20-26 / %x28-5B / %x5D-10FFFF
+
+escape = %x5C                 ; \
+
+HEXDIG =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+DIGIT =  %x30-39              ; 0-9
                      </sourcecode>
-                     <t>Note: the syntax does not allow any character other than a quote or reverse solidus to be escaped.
+                     <t>Note: double-quoted strings follow JSON in <xref target="RFC8259" format="default">RFC&nbsp;8259</xref>.
+                        Single-quoted strings follow an analogous pattern.
                      </t>
                   </section>       
                   <section numbered="false" toc="exclude">
                      <name>Semantics</name>
-                     <t>If the union child is a quoted string, the string must first have the surrounding quotes removed and then be unescaped
-                        as describe below.
-                        The union child matches any node which is an object having a key equal to the unescaped value of the union child string
-                        and selects the value corresponding to that key.
-                        It does not match a node which is not an object.
+                     <t>If the union child is a quoted string, the string MUST be converted to a key by removing the surrounding quotes and
+                        replacing each escape sequence with its equivalent Unicode character, as in the table below:
                      </t>
-                     <t>After the surrounding quotes have been removed, a string is unescaped by replacing each escaped quote by the corresponding
-                        quote and replacing each escaped reverse solidus by a reverse solidus.
+                     <table>
+                        <name>Escape Sequence Replacements</name>
+                        <thead>
+                           <tr><th align='center'>Escape Sequence</th> <th align='center'>Unicode Character</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <tr>   <td align='center'>%x5C %x22</td>         <td align='center'>U+0022</td></tr>
+                           <tr>   <td align='center'>%x5C %x27</td>         <td align='center'>U+0027</td></tr>
+                           <tr>   <td align='center'>%x5C %x2F</td>         <td align='center'>U+002F</td></tr>
+                           <tr>   <td align='center'>%x5C %x5C</td>         <td align='center'>U+005C</td></tr>
+                           <tr>   <td align='center'>%x5C %x62</td>         <td align='center'>U+0008</td></tr>
+                           <tr>   <td align='center'>%x5C %x66</td>         <td align='center'>U+000C</td></tr>
+                           <tr>   <td align='center'>%x5C %x6E</td>         <td align='center'>U+000A</td></tr>
+                           <tr>   <td align='center'>%x5C %x72</td>         <td align='center'>U+000D</td></tr>
+                           <tr>   <td align='center'>%x5C %x74</td>         <td align='center'>U+0009</td></tr>
+                           <tr>   <td align='center'>%x5C uXXXX</td>        <td align='center'>U+XXXX</td></tr>
+                        </tbody>
+                     </table>
+                     <t>
+                        The union child matches any node which is an object with this key and selects the value corresponding to the key.
+                        It does not match a node which is not an object.
                      </t>
                   </section>       
                </section>             


### PR DESCRIPTION
Also define encoding of paths.

Also use JSON Path instead of JSONPath.

See [rendered HTML](https://glyn.github.io/internet-draft/) for ease of reading.