### PR TITLE
Editorial changes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1246,55 +1246,55 @@ dt+dd:empty::before{
         <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents-2">
 <a href="#name-table-of-contents-2" class="section-name selfRef">Table of Contents</a>
         </h2>
-<nav class="toc"><ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.1">
+<nav class="toc"><ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.1">
             <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction-2" class="xref">Introduction</a><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.1.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.1.2.1">
                 <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="xref">1.1</a>.  <a href="#name-requirements-language-2" class="xref">Requirements Language</a><a href="#section-toc.1-1.1.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.1.2.2">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.1.2.2">
                 <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="xref">1.2</a>.  <a href="#name-abnf-syntax-2" class="xref">ABNF Syntax</a><a href="#section-toc.1-1.1.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.2">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.2">
             <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-json-path-syntax-and-semanti" class="xref">JSON Path Syntax and Semantics</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.2.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.2.2.1">
                 <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-overview-2" class="xref">Overview</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.2">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.2">
                 <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-terminology-2" class="xref">Terminology</a><a href="#section-toc.1-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.3">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.3">
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-implementation-2" class="xref">Implementation</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.4">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.4">
                 <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-6" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.5">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.5">
                 <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-6" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6">
                 <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="xref">2.6</a>.  <a href="#name-matchers-2" class="xref">Matchers</a><a href="#section-toc.1-1.2.2.6.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.1">
                     <p id="section-toc.1-1.2.2.6.2.1.1"><a href="#section-2.6.1" class="xref">2.6.1</a>.  <a href="#name-dot-child-matcher-2" class="xref">Dot Child Matcher</a><a href="#section-toc.1-1.2.2.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2">
+                  <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2">
                     <p id="section-toc.1-1.2.2.6.2.2.1"><a href="#section-2.6.2" class="xref">2.6.2</a>.  <a href="#name-union-matcher-2" class="xref">Union Matcher</a><a href="#section-toc.1-1.2.2.6.2.2.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.1">
                         <p id="section-toc.1-1.2.2.6.2.2.2.1.1"><a href="#section-2.6.2.1" class="xref">2.6.2.1</a>.  <a href="#name-syntax-8" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.6.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
-                      <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.2">
+                      <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.2">
                         <p id="section-toc.1-1.2.2.6.2.2.2.2.1"><a href="#section-2.6.2.2" class="xref">2.6.2.2</a>.  <a href="#name-semantics-8" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.6.2.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
-                      <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.3">
+                      <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.3">
                         <p id="section-toc.1-1.2.2.6.2.2.2.3.1"><a href="#section-2.6.2.3" class="xref">2.6.2.3</a>.  <a href="#name-union-child-2" class="xref">Union Child</a><a href="#section-toc.1-1.2.2.6.2.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
-                      <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.4">
+                      <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.4">
                         <p id="section-toc.1-1.2.2.6.2.2.2.4.1"><a href="#section-2.6.2.4" class="xref">2.6.2.4</a>.  <a href="#name-array-index-2" class="xref">Array Index</a><a href="#section-toc.1-1.2.2.6.2.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
                     </ul>
@@ -1303,27 +1303,27 @@ dt+dd:empty::before{
 </li>
             </ul>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.3">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.3">
             <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-iana-considerations-2" class="xref">IANA Considerations</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.4">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.4">
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-security-considerations-2" class="xref">Security Considerations</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.5">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.5">
             <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-alternatives-2" class="xref">Alternatives</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.6">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.6">
             <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-references-2" class="xref">References</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.6.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.6.2.1">
                 <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-normative-references-2" class="xref">Normative References</a><a href="#section-toc.1-1.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.2">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.6.2.2">
                 <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-informative-references-2" class="xref">Informative References</a><a href="#section-toc.1-1.6.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.7">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.7">
             <p id="section-toc.1-1.7.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-authors-addresses-2" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
@@ -1443,24 +1443,24 @@ root-selector = %x24               ; $ selects document root node
 <p id="section-2.6.1.1-2">A dot child name corresponds to a name in a JSON object.<a href="#section-2.6.1.1-2" class="pilcrow">¶</a></p>
 <div id="section-2.6.1.1-3">
 <pre class="sourcecode lang-abnf">
-matcher = dot-child             ; see below for alternatives
+matcher = dot-child               ; see below for alternatives
 dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
             %x2E %x2A             ; .*
 dot-child-name = 1*(
-                   %x2D / ; -
+                   %x2D /         ; -
                    DIGIT /
                    ALPHA /
-                   %x5F / ; _
-                   %x80-10FFFF ; any non-ASCII Unicode character
+                   %x5F /         ; _
+                   %x80-10FFFF    ; any non-ASCII Unicode character
                  )
-DIGIT =  %x30-39 ; 0-9
-ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
+DIGIT =  %x30-39                  ; 0-9
+ALPHA = %x41-5A / %x61-7A         ; A-Z / a-z
 </pre><a href="#section-2.6.1.1-3" class="pilcrow">¶</a>
 </div>
 <p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Union Child" (<a href="#unionchild" class="xref">Section 2.6.2.3</a>).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
-<p id="section-2.6.1.1-5">Note that <code>dot-child-name</code> rule follows the philosophy of JSON strings when working with non-ASCII range of Unicode: it's
-                     allowed to contain bit sequences that cannot encode Unicode character (an single unpaired UTF-16 surrogate, for example). It can lead
-                     to unpredictable behavior of software that receives such query.<a href="#section-2.6.1.1-5" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.1-5">Note that the <code>dot-child-name</code> rule follows the philosophy of JSON strings and is
+                     allowed to contain bit sequences that cannot encode Unicode characters (a single unpaired UTF-16 surrogate, for example).
+                     The behaviour of an implementation is undefined for child names which do not encode Unicode characters.<a href="#section-2.6.1.1-5" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6.1.2">
             <h5 id="name-semantics-7">
@@ -1468,7 +1468,7 @@ ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
             </h5>
 <p id="section-2.6.1.2-1">A dot child name which is not a single asterisk (<code>*</code>) is considered to have a key. It matches any node which is an object having a name equal to that key
                       and selects the value corresponding to that name. It does not match a node which is not an object.<a href="#section-2.6.1.2-1" class="pilcrow">¶</a></p>
-<p id="section-2.6.1.2-2">The key of a dot child name is the sequence of Unicode symbols contained in that name.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.2-2">The key of a dot child name is the sequence of Unicode characters contained in that name.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
 <p id="section-2.6.1.2-3">A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
                      It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.<a href="#section-2.6.1.2-3" class="pilcrow">¶</a></p>
 </section>

--- a/draft-normington-jsonpath-latest.html
+++ b/draft-normington-jsonpath-latest.html
@@ -1246,55 +1246,55 @@ dt+dd:empty::before{
         <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents-2">
 <a href="#name-table-of-contents-2" class="section-name selfRef">Table of Contents</a>
         </h2>
-<nav class="toc"><ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.1">
+<nav class="toc"><ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.1">
             <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction-2" class="xref">Introduction</a><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.1.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.1.2.1">
                 <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="xref">1.1</a>.  <a href="#name-requirements-language-2" class="xref">Requirements Language</a><a href="#section-toc.1-1.1.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.1.2.2">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.1.2.2">
                 <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="xref">1.2</a>.  <a href="#name-abnf-syntax-2" class="xref">ABNF Syntax</a><a href="#section-toc.1-1.1.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.2">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.2">
             <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-json-path-syntax-and-semanti" class="xref">JSON Path Syntax and Semantics</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.2.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.2.2.1">
                 <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-overview-2" class="xref">Overview</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.2">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.2">
                 <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-terminology-2" class="xref">Terminology</a><a href="#section-toc.1-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.3">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.3">
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-implementation-2" class="xref">Implementation</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.4">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.4">
                 <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-syntax-6" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.5">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.5">
                 <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-semantics-6" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6">
                 <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="xref">2.6</a>.  <a href="#name-matchers-2" class="xref">Matchers</a><a href="#section-toc.1-1.2.2.6.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.1">
                     <p id="section-toc.1-1.2.2.6.2.1.1"><a href="#section-2.6.1" class="xref">2.6.1</a>.  <a href="#name-dot-child-matcher-2" class="xref">Dot Child Matcher</a><a href="#section-toc.1-1.2.2.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2">
+                  <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2">
                     <p id="section-toc.1-1.2.2.6.2.2.1"><a href="#section-2.6.2" class="xref">2.6.2</a>.  <a href="#name-union-matcher-2" class="xref">Union Matcher</a><a href="#section-toc.1-1.2.2.6.2.2.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.1">
                         <p id="section-toc.1-1.2.2.6.2.2.2.1.1"><a href="#section-2.6.2.1" class="xref">2.6.2.1</a>.  <a href="#name-syntax-8" class="xref">Syntax</a><a href="#section-toc.1-1.2.2.6.2.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
-                      <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.2">
+                      <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.2">
                         <p id="section-toc.1-1.2.2.6.2.2.2.2.1"><a href="#section-2.6.2.2" class="xref">2.6.2.2</a>.  <a href="#name-semantics-8" class="xref">Semantics</a><a href="#section-toc.1-1.2.2.6.2.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
-                      <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.3">
+                      <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.3">
                         <p id="section-toc.1-1.2.2.6.2.2.2.3.1"><a href="#section-2.6.2.3" class="xref">2.6.2.3</a>.  <a href="#name-union-child-2" class="xref">Union Child</a><a href="#section-toc.1-1.2.2.6.2.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
-                      <li class="ulEmpty compact toc" id="section-toc.1-1.2.2.6.2.2.2.4">
+                      <li class="ulEmpty toc compact" id="section-toc.1-1.2.2.6.2.2.2.4">
                         <p id="section-toc.1-1.2.2.6.2.2.2.4.1"><a href="#section-2.6.2.4" class="xref">2.6.2.4</a>.  <a href="#name-array-index-2" class="xref">Array Index</a><a href="#section-toc.1-1.2.2.6.2.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
                     </ul>
@@ -1303,27 +1303,27 @@ dt+dd:empty::before{
 </li>
             </ul>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.3">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.3">
             <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-iana-considerations-2" class="xref">IANA Considerations</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.4">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.4">
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-security-considerations-2" class="xref">Security Considerations</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.5">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.5">
             <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-alternatives-2" class="xref">Alternatives</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.6">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.6">
             <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-references-2" class="xref">References</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.6.2.1">
+<ul class="ulEmpty toc compact">
+<li class="ulEmpty toc compact" id="section-toc.1-1.6.2.1">
                 <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-normative-references-2" class="xref">Normative References</a><a href="#section-toc.1-1.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.2">
+              <li class="ulEmpty toc compact" id="section-toc.1-1.6.2.2">
                 <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-informative-references-2" class="xref">Informative References</a><a href="#section-toc.1-1.6.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.7">
+          <li class="ulEmpty toc compact" id="section-toc.1-1.7">
             <p id="section-toc.1-1.7.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-authors-addresses-2" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
@@ -1443,24 +1443,24 @@ root-selector = %x24               ; $ selects document root node
 <p id="section-2.6.1.1-2">A dot child name corresponds to a name in a JSON object.<a href="#section-2.6.1.1-2" class="pilcrow">¶</a></p>
 <div id="section-2.6.1.1-3">
 <pre class="sourcecode lang-abnf">
-matcher = dot-child             ; see below for alternatives
+matcher = dot-child               ; see below for alternatives
 dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
             %x2E %x2A             ; .*
 dot-child-name = 1*(
-                   %x2D / ; -
+                   %x2D /         ; -
                    DIGIT /
                    ALPHA /
-                   %x5F / ; _
-                   %x80-10FFFF ; any non-ASCII Unicode character
+                   %x5F /         ; _
+                   %x80-10FFFF    ; any non-ASCII Unicode character
                  )
-DIGIT =  %x30-39 ; 0-9
-ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
+DIGIT =  %x30-39                  ; 0-9
+ALPHA = %x41-5A / %x61-7A         ; A-Z / a-z
 </pre><a href="#section-2.6.1.1-3" class="pilcrow">¶</a>
 </div>
 <p id="section-2.6.1.1-4">More general child names, such as the empty string, are supported by "Union Child" (<a href="#unionchild" class="xref">Section 2.6.2.3</a>).<a href="#section-2.6.1.1-4" class="pilcrow">¶</a></p>
-<p id="section-2.6.1.1-5">Note that <code>dot-child-name</code> rule follows the philosophy of JSON strings when working with non-ASCII range of Unicode: it's
-                     allowed to contain bit sequences that cannot encode Unicode character (an single unpaired UTF-16 surrogate, for example). It can lead
-                     to unpredictable behavior of software that receives such query.<a href="#section-2.6.1.1-5" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.1-5">Note that the <code>dot-child-name</code> rule follows the philosophy of JSON strings and is
+                     allowed to contain bit sequences that cannot encode Unicode characters (a single unpaired UTF-16 surrogate, for example).
+                     The behaviour of an implementation is undefined for child names which do not encode Unicode characters.<a href="#section-2.6.1.1-5" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2.6.1.2">
             <h5 id="name-semantics-7">
@@ -1468,7 +1468,7 @@ ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
             </h5>
 <p id="section-2.6.1.2-1">A dot child name which is not a single asterisk (<code>*</code>) is considered to have a key. It matches any node which is an object having a name equal to that key
                       and selects the value corresponding to that name. It does not match a node which is not an object.<a href="#section-2.6.1.2-1" class="pilcrow">¶</a></p>
-<p id="section-2.6.1.2-2">The key of a dot child name is the sequence of Unicode symbols contained in that name.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.6.1.2-2">The key of a dot child name is the sequence of Unicode characters contained in that name.<a href="#section-2.6.1.2-2" class="pilcrow">¶</a></p>
 <p id="section-2.6.1.2-3">A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
                      It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.<a href="#section-2.6.1.2-3" class="pilcrow">¶</a></p>
 </section>

--- a/draft-normington-jsonpath-latest.txt
+++ b/draft-normington-jsonpath-latest.txt
@@ -282,27 +282,27 @@ Normington & Surov        Expires 27 March 2021                 [Page 5]
 Internet-Draft   JavaScript Object Notation (JSON) Path   September 2020
 
 
-   matcher = dot-child             ; see below for alternatives
+   matcher = dot-child               ; see below for alternatives
    dot-child = %x2E dot-child-name / ; .<dot-child-name>
                %x2E %x2A             ; .*
    dot-child-name = 1*(
-                      %x2D / ; -
+                      %x2D /         ; -
                       DIGIT /
                       ALPHA /
-                      %x5F / ; _
-                      %x80-10FFFF ; any non-ASCII Unicode character
+                      %x5F /         ; _
+                      %x80-10FFFF    ; any non-ASCII Unicode character
                     )
-   DIGIT =  %x30-39 ; 0-9
-   ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
+   DIGIT =  %x30-39                  ; 0-9
+   ALPHA = %x41-5A / %x61-7A         ; A-Z / a-z
 
    More general child names, such as the empty string, are supported by
    "Union Child" (Section 2.6.2.3).
 
-   Note that "dot-child-name" rule follows the philosophy of JSON
-   strings when working with non-ASCII range of Unicode: it's allowed to
-   contain bit sequences that cannot encode Unicode character (an single
-   unpaired UTF-16 surrogate, for example).  It can lead to
-   unpredictable behavior of software that receives such query.
+   Note that the "dot-child-name" rule follows the philosophy of JSON
+   strings and is allowed to contain bit sequences that cannot encode
+   Unicode characters (a single unpaired UTF-16 surrogate, for example).
+   The behaviour of an implementation is undefined for child names which
+   do not encode Unicode characters.
 
 Semantics
 
@@ -311,7 +311,7 @@ Semantics
    equal to that key and selects the value corresponding to that name.
    It does not match a node which is not an object.
 
-   The key of a dot child name is the sequence of Unicode symbols
+   The key of a dot child name is the sequence of Unicode characters
    contained in that name.
 
    A dot child name consisting of a single asterisk is a wild card.  It

--- a/draft-normington-jsonpath-latest.xml
+++ b/draft-normington-jsonpath-latest.xml
@@ -219,18 +219,18 @@ root-selector = %x24               ; $ selects document root node
                   <t>A dot child name corresponds to a name in a JSON object.
                   </t>
                   <sourcecode type="abnf">
-matcher = dot-child             ; see below for alternatives
+matcher = dot-child               ; see below for alternatives
 dot-child = %x2E dot-child-name / ; .&lt;dot-child-name&gt;
             %x2E %x2A             ; .*
 dot-child-name = 1*(
-                   %x2D / ; -
+                   %x2D /         ; -
                    DIGIT /
                    ALPHA /
-                   %x5F / ; _
-                   %x80-10FFFF ; any non-ASCII Unicode character
+                   %x5F /         ; _
+                   %x80-10FFFF    ; any non-ASCII Unicode character
                  )
-DIGIT =  %x30-39 ; 0-9
-ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
+DIGIT =  %x30-39                  ; 0-9
+ALPHA = %x41-5A / %x61-7A         ; A-Z / a-z
                   </sourcecode>
                   <t>More general child names, such as the empty string, are supported by "Union Child" (<xref target="unionchild" format="default"/>).
                   </t>
@@ -244,7 +244,7 @@ ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
                   <t>A dot child name which is not a single asterisk (<tt>*</tt>) is considered to have a key. It matches any node which is an object having a name equal to that key
                       and selects the value corresponding to that name. It does not match a node which is not an object.
                   </t>
-                   <t>The key of a dot child name is the sequence of Unicode symbols contained in that name.
+                   <t>The key of a dot child name is the sequence of Unicode characters contained in that name.
                    </t>
                   <t>A dot child name consisting of a single asterisk is a wild card. It matches any node which is an object and selects all the values of the object.
                      It also matches any node which is an array and selects all the elements of the array. It does not match a number, string, or literal node.


### PR DESCRIPTION
Align ABNF comments.

Use the term Unicode characters rather than Unicode symbols for consistency.

(Also regenerate, which fills in for a missing generate at master.)