### PR TITLE
Use xpath to feed only abnf soucecode to aex and bap

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && apt-get install -y \
     git \
     python3-pip \
     bison \
-    flex
+    flex \
+    xmlstarlet
 
 RUN pip3 install xml2rfc
 

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -8,14 +8,7 @@ readonly script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$script_dir/.."
 
 xml2rfc ./draft-normington-jsonpath-latest.xml --text --html && \
-aex draft-normington-jsonpath-latest.txt \
-| grep -v "lower =" \
-| grep -v "upper =" \
-| grep -v "i =" \
-| grep -v "step =" \
-| grep -v "step &gt;=" \
-| grep -v "start =" \
-| grep -v "end =" \
+xmlstarlet sel -T -t -v '//sourcecode[@type="abnf"]' ./draft-normington-jsonpath-latest.xml 2>/dev/null \
+| aex \
 | bap -S path -q && cp draft-normington-jsonpath-latest.html docs/index.html
-# TODO fix aex to not extract ABNF-looking rules from pseudocode blocks
 )


### PR DESCRIPTION
thus avoding other types of sourcecode (such as pseudocode) to be validated by the ABNF checker.

aex is still needed because it reformats the content for bap somehow (didn't investigate).